### PR TITLE
Various fixes

### DIFF
--- a/src/glsl/ir_print_glsl_visitor.cpp
+++ b/src/glsl/ir_print_glsl_visitor.cpp
@@ -407,7 +407,7 @@ static const char *const operator_glsl_strs[] = {
 	"-",
 	"*",
 	"/",
-	"%",
+	"mod",
 	"<",
 	">",
 	"<=",
@@ -435,16 +435,23 @@ void ir_print_glsl_visitor::visit(ir_expression *ir)
 {
 	if (ir->get_num_operands() == 1) {
 		if (ir->operation >= ir_unop_f2i && ir->operation <= ir_unop_u2f) {
-			buffer = print_type(buffer, ir->type, true);
 			ralloc_asprintf_append (&buffer, "(");
+			buffer = print_type(buffer, ir->type, true);
+			ralloc_asprintf_append(&buffer, "(");
 		} else {
-			ralloc_asprintf_append (&buffer, "%s(", operator_glsl_strs[ir->operation]);
+			ralloc_asprintf_append (&buffer, "(%s(", operator_glsl_strs[ir->operation]);
 		}
 		if (ir->operands[0])
 			ir->operands[0]->accept(this);
-		ralloc_asprintf_append (&buffer, ")");
+		ralloc_asprintf_append (&buffer, "))");
 	}
-	else if (ir->operation == ir_binop_equal || ir->operation == ir_binop_nequal) {
+	else if (ir->operation == ir_binop_equal || ir->operation == ir_binop_nequal || ir->operation == ir_binop_mod) {
+		if (ir->operation == ir_binop_mod)
+		{
+			ralloc_asprintf_append (&buffer, "(");
+			buffer = print_type(buffer, ir->type, true);
+			ralloc_asprintf_append (&buffer, "(");
+	}
 		ralloc_asprintf_append (&buffer, "%s (", operator_glsl_strs[ir->operation]);
 		if (ir->operands[0])
 			ir->operands[0]->accept(this);
@@ -452,6 +459,8 @@ void ir_print_glsl_visitor::visit(ir_expression *ir)
 		if (ir->operands[1])
 			ir->operands[1]->accept(this);
 		ralloc_asprintf_append (&buffer, ")");
+		if (ir->operation == ir_binop_mod)
+            ralloc_asprintf_append (&buffer, "))");
 	}
 	else {
 		ralloc_asprintf_append (&buffer, "(");
@@ -464,6 +473,7 @@ void ir_print_glsl_visitor::visit(ir_expression *ir)
 			ir->operands[1]->accept(this);
 		ralloc_asprintf_append (&buffer, ")");
 	}
+
 }
 
 


### PR DESCRIPTION
Hi,

Here are some fixes for the glsl code generator bug I encountered while optimizing our engine glsl code (translated from hlsl with hlsl2glslfork :) ),  I did not run the test suite as the test app is not Linux compatible yet, but the results should be changed mainly due to more paranoid parenthesis.

Cheers,

Maxime Coste.

P.S. there looks to be a bug in copy_propagation elements code, I saw
a.xy = a.yx;
a.x = -a.x;
becoming
a.xy = a.yx;
a.x = -a.y;
I'm investigating
