### PR TITLE
Updates and fixes for cmake build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ glsl_main
 glsl_test
 glcpp
 glslopt
+glsl_compiler
+.settings/
+.pydevproject

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,17 +5,33 @@ include_directories(src/mesa)
 include_directories(src/mapi)
 include_directories(src/glsl)
 
+option (DEBUG "Enable debugging" FALSE)
+
+if(${DEBUG} MATCHES "on")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -O0")
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -O0")
+else()
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Os -DNDEBUG")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Os -DNDEBUG")
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -s")
+endif()
+
 file(GLOB glcpp-library_sources src/glsl/glcpp/*.c)
-list(REMOVE_ITEM glcpp-library_sources src/glsl/glcpp/glcpp.c)
+file(GLOB glcpp-library_sources_remove src/glsl/glcpp/glcpp.c)
+list(REMOVE_ITEM glcpp-library_sources ${glcpp-library_sources_remove})
 add_library(glcpp-library ${glcpp-library_sources})
 
 file(GLOB mesa_sources src/mesa/program/*.c)
 add_library(mesa ${mesa_sources})
 
 file(GLOB glsl_sources src/glsl/*.cpp src/glsl/*.c)
-list(REMOVE_ITEM glsl_sources src/glsl/main.cpp)
+file(GLOB glsl_sources_remove src/glsl/main.cpp src/glsl/builtin_stubs.cpp)
+list(REMOVE_ITEM glsl_sources ${glsl_sources_remove})
 add_library(glsl_optimizer ${glsl_sources})
 target_link_libraries(glsl_optimizer glcpp-library mesa)
+
+add_executable(glsl_compiler src/glsl/main.cpp)
+target_link_libraries(glsl_compiler glsl_optimizer)
 
 file(GLOB glsl_test_sources tests/*.cpp)
 add_executable(glsl_test ${glsl_test_sources})
@@ -25,6 +41,5 @@ file(GLOB glslopt_sources contrib/glslopt/*.cpp)
 add_executable(glslopt ${glslopt_sources})
 target_link_libraries(glslopt glsl_optimizer)
 
-file(GLOB glcpp_sources src/glsl/glcpp/glcpp.c)
-add_executable(glcpp ${glcpp_sources})
+add_executable(glcpp src/glsl/glcpp/glcpp.c)
 target_link_libraries(glcpp glsl_optimizer)


### PR DESCRIPTION
I didn't have a chance to properly test the glsl optimizer last time.
These changes fix all problems. The tests now all pass using the glsl_test binary.

Changelog:
added glsl_optimizer binary
fixed compilation of builtin_functions.cpp
fixed removal of some unnecessary source files
added DEBUG(=on/off) switch
