### PR TITLE
Fix MSVC8 compilation error: INFINITY constant does not exist

### DIFF
--- a/src/glsl/ir_constant_expression.cpp
+++ b/src/glsl/ir_constant_expression.cpp
@@ -576,15 +576,10 @@ ir_expression::constant_expression_value(struct hash_table *variable_context)
 		for (unsigned c = 0; c < op[0]->type->components(); c++) {
 			mag2 += op[0]->value.f[c] * op[0]->value.f[c];
 		}
-		if ( mag2!=0.0f ) {
-			float mag = sqrtf(mag2);
-			for (unsigned c = 0; c < op[0]->type->components(); c++) {
-				data.f[c] = op[0]->value.f[c] / mag;
-			}
-		} else {
-			for (unsigned c = 0; c < op[0]->type->components(); c++) {
-				data.f[c] = op[0]->value.f[c]>=0.0f ? INFINITY : -INFINITY;
-			}
+
+		float mag = sqrtf(mag2);
+		for (unsigned c = 0; c < op[0]->type->components(); c++) {
+			data.f[c] = op[0]->value.f[c] / mag;
 		}
 	}
 	break;      


### PR DESCRIPTION
IEEE754-compliant math will do the right thing here without extra checks.

And by "the right thing" I mean "normalize(float3(0,0,0)) will return float3(NaN, NaN, NaN)".
Not sure how NaN (or Infinity, for that matter) is translated into GLSL...
