### PR TITLE
Add printing of constant struct initializer

### DIFF
--- a/src/glsl/ir_print_glsl_visitor.cpp
+++ b/src/glsl/ir_print_glsl_visitor.cpp
@@ -1036,7 +1036,16 @@ void ir_print_glsl_visitor::visit(ir_constant *ir)
 	    ralloc_asprintf_append (&buffer, ", ");
 	 ir->get_array_element(i)->accept(this);
       }
-   } else {
+   } else if (ir->type->is_record()) {
+      bool first = true;
+      foreach_iter(exec_list_iterator, iter, ir->components) {
+	 if (!first)
+	    ralloc_asprintf_append (&buffer, ", ");
+	 first = false;
+	 ir_constant* inst = (ir_constant*)iter.get();
+	 inst->accept(this);
+     } 
+   }else {
       bool first = true;
       for (unsigned i = 0; i < ir->type->components(); i++) {
 	 if (!first)


### PR DESCRIPTION
I got the situation when shaders refused to compile due to lack of constant initializers for fields in the struct initialization. This patch contains code which care about constant records along with present arrays and matrix code.
