### PR TITLE
Allow to customize max loop unroll iterations.

### DIFF
--- a/src/glsl/glsl_optimizer.h
+++ b/src/glsl/glsl_optimizer.h
@@ -45,6 +45,8 @@ enum glslopt_target {
 glslopt_ctx* glslopt_initialize (glslopt_target target);
 void glslopt_cleanup (glslopt_ctx* ctx);
 
+void glslopt_set_max_unroll_iterations (glslopt_ctx* ctx, unsigned iterations);
+
 glslopt_shader* glslopt_optimize (glslopt_ctx* ctx, glslopt_shader_type type, const char* shaderSource, unsigned options);
 bool glslopt_get_status (glslopt_shader* shader);
 const char* glslopt_get_output (glslopt_shader* shader);


### PR DESCRIPTION
The default 8 is too low for some shaders, especially given the loop body
complexity of 15 in unroll_loops. Ideally need to tweak that as well, but
externally controlled iteration count allows to set it to be very large
to force all loops to unroll.
