### PR TITLE
Use glob to find all source files to avoid missing symbols

### DIFF
--- a/src/glsl_optimizer_lib.gyp
+++ b/src/glsl_optimizer_lib.gyp
@@ -17,7 +17,8 @@
         ],
       },
       'sources': [
-        '<!@(find {glsl,mesa} -name "*.cpp" -or -name "*.c" -or -name "*.h")',
+        '<!@(find glsl -name "*.cpp" -or -name "*.c" -or -name "*.h")',
+        '<!@(find mesa -name "*.cpp" -or -name "*.c" -or -name "*.h")',
       ],
       'conditions': [
         ['OS=="win"', {


### PR DESCRIPTION
Fixes missing symbols when building the node extension
