### PR TITLE
Fixing Author & URLs in Package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,14 @@
   },
   "keywords": [
     "glsl",
-    "webgl"
+    "webgl",
+    "shader",
+    "optimize",
+    "optimizer",
+    "opengl",
+    "essl",
+    "es",
+    "opengles"
   ],
   "readmeFilename": "README.md",
   "author": "Aras Pranckevičius",


### PR DESCRIPTION
Fixing some package.json details leftover from Don Olmstead's node fork.
