### PR TITLE
Only link shader if kGlslOptionNotFullShader is not present

### DIFF
--- a/src/glsl/glsl_optimizer.cpp
+++ b/src/glsl/glsl_optimizer.cpp
@@ -436,7 +436,7 @@ glslopt_shader* glslopt_optimize (glslopt_ctx* ctx, glslopt_shader_type type, co
 	
 	struct gl_shader* linked_shader = NULL;
 
-	if (!state->error && !ir->is_empty())
+	if (!state->error && !ir->is_empty() && !(options & kGlslOptionNotFullShader))
 	{
 		linked_shader = link_intrastage_shaders(shader,
 												&ctx->mesa_ctx,


### PR DESCRIPTION
This patch makes it possible to provide a shader without "main" if "kGlslOptionNotFullShader" is set.
All tests pass.
