### PR TITLE
updated ir_print_glsl_visitor to preserve uniform block definitions on on output

### DIFF
--- a/projects/vs2013/glsl_optimizer.sln
+++ b/projects/vs2013/glsl_optimizer.sln
@@ -1,0 +1,62 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2013
+VisualStudioVersion = 12.0.31101.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "glsl_optimizer_lib", "glsl_optimizer_lib.vcxproj", "{B475A403-9D9B-410D-8A93-BA49FC4DD811}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "glsl_optimizer_tests", "glsl_optimizer_tests.vcxproj", "{BB382242-6EBB-445F-989C-B9BA61D17965}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "glslopt", "glslopt\glslopt.vcxproj", "{7D22C13A-C5B0-4FC4-BC2A-E9567025826E}"
+	ProjectSection(ProjectDependencies) = postProject
+		{B475A403-9D9B-410D-8A93-BA49FC4DD811} = {B475A403-9D9B-410D-8A93-BA49FC4DD811}
+	EndProjectSection
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Mixed Platforms = Debug|Mixed Platforms
+		Debug|Win32 = Debug|Win32
+		Debug|x64 = Debug|x64
+		Release|Mixed Platforms = Release|Mixed Platforms
+		Release|Win32 = Release|Win32
+		Release|x64 = Release|x64
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{B475A403-9D9B-410D-8A93-BA49FC4DD811}.Debug|Mixed Platforms.ActiveCfg = Debug|Win32
+		{B475A403-9D9B-410D-8A93-BA49FC4DD811}.Debug|Mixed Platforms.Build.0 = Debug|Win32
+		{B475A403-9D9B-410D-8A93-BA49FC4DD811}.Debug|Win32.ActiveCfg = Debug|Win32
+		{B475A403-9D9B-410D-8A93-BA49FC4DD811}.Debug|Win32.Build.0 = Debug|Win32
+		{B475A403-9D9B-410D-8A93-BA49FC4DD811}.Debug|x64.ActiveCfg = Debug|x64
+		{B475A403-9D9B-410D-8A93-BA49FC4DD811}.Debug|x64.Build.0 = Debug|x64
+		{B475A403-9D9B-410D-8A93-BA49FC4DD811}.Release|Mixed Platforms.ActiveCfg = Release|Win32
+		{B475A403-9D9B-410D-8A93-BA49FC4DD811}.Release|Mixed Platforms.Build.0 = Release|Win32
+		{B475A403-9D9B-410D-8A93-BA49FC4DD811}.Release|Win32.ActiveCfg = Release|Win32
+		{B475A403-9D9B-410D-8A93-BA49FC4DD811}.Release|Win32.Build.0 = Release|Win32
+		{B475A403-9D9B-410D-8A93-BA49FC4DD811}.Release|x64.ActiveCfg = Release|x64
+		{B475A403-9D9B-410D-8A93-BA49FC4DD811}.Release|x64.Build.0 = Release|x64
+		{BB382242-6EBB-445F-989C-B9BA61D17965}.Debug|Mixed Platforms.ActiveCfg = Debug|Win32
+		{BB382242-6EBB-445F-989C-B9BA61D17965}.Debug|Mixed Platforms.Build.0 = Debug|Win32
+		{BB382242-6EBB-445F-989C-B9BA61D17965}.Debug|Win32.ActiveCfg = Debug|Win32
+		{BB382242-6EBB-445F-989C-B9BA61D17965}.Debug|x64.ActiveCfg = Debug|x64
+		{BB382242-6EBB-445F-989C-B9BA61D17965}.Release|Mixed Platforms.ActiveCfg = Release|Win32
+		{BB382242-6EBB-445F-989C-B9BA61D17965}.Release|Mixed Platforms.Build.0 = Release|Win32
+		{BB382242-6EBB-445F-989C-B9BA61D17965}.Release|Win32.ActiveCfg = Release|Win32
+		{BB382242-6EBB-445F-989C-B9BA61D17965}.Release|x64.ActiveCfg = Release|x64
+		{BB382242-6EBB-445F-989C-B9BA61D17965}.Release|x64.Build.0 = Release|x64
+		{7D22C13A-C5B0-4FC4-BC2A-E9567025826E}.Debug|Mixed Platforms.ActiveCfg = Debug|Win32
+		{7D22C13A-C5B0-4FC4-BC2A-E9567025826E}.Debug|Mixed Platforms.Build.0 = Debug|Win32
+		{7D22C13A-C5B0-4FC4-BC2A-E9567025826E}.Debug|Win32.ActiveCfg = Debug|Win32
+		{7D22C13A-C5B0-4FC4-BC2A-E9567025826E}.Debug|Win32.Build.0 = Debug|Win32
+		{7D22C13A-C5B0-4FC4-BC2A-E9567025826E}.Debug|x64.ActiveCfg = Debug|x64
+		{7D22C13A-C5B0-4FC4-BC2A-E9567025826E}.Debug|x64.Build.0 = Debug|x64
+		{7D22C13A-C5B0-4FC4-BC2A-E9567025826E}.Release|Mixed Platforms.ActiveCfg = Release|Win32
+		{7D22C13A-C5B0-4FC4-BC2A-E9567025826E}.Release|Mixed Platforms.Build.0 = Release|Win32
+		{7D22C13A-C5B0-4FC4-BC2A-E9567025826E}.Release|Win32.ActiveCfg = Release|Win32
+		{7D22C13A-C5B0-4FC4-BC2A-E9567025826E}.Release|Win32.Build.0 = Release|Win32
+		{7D22C13A-C5B0-4FC4-BC2A-E9567025826E}.Release|x64.ActiveCfg = Release|x64
+		{7D22C13A-C5B0-4FC4-BC2A-E9567025826E}.Release|x64.Build.0 = Release|x64
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/projects/vs2013/glsl_optimizer_lib.vcxproj
+++ b/projects/vs2013/glsl_optimizer_lib.vcxproj
@@ -1,0 +1,377 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{B475A403-9D9B-410D-8A93-BA49FC4DD811}</ProjectGuid>
+    <RootNamespace>glsl_optimizer_lib</RootNamespace>
+    <Keyword>Win32Proj</Keyword>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
+    <PlatformToolset>v120</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v120</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
+    <PlatformToolset>v120</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v120</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">build/$(ProjectName)\$(Configuration)\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">build/$(ProjectName)\$(Configuration)\</IntDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">build/$(ProjectName)/$(Platform)/$(Configuration)\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">build/$(ProjectName)/$(Platform)/$(Configuration)\</IntDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">build/$(Platform)\$(Configuration)\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">build/$(Platform)\$(Configuration)\</IntDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|x64'">build/$(ProjectName)/$(Platform)/$(Configuration)\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|x64'">build/$(ProjectName)/$(Platform)/$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>../../src/mesa;../../src;../../include/c99;../../include;../../src/glsl;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;NOMINMAX;_CRT_SECURE_NO_WARNINGS;_CRT_SECURE_NO_DEPRECATE;__STDC_VERSION__=199901L;__STDC__;strdup=_strdup;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MinimalRebuild>false</MinimalRebuild>
+      <ExceptionHandling>
+      </ExceptionHandling>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <DisableSpecificWarnings>4996;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <ForcedIncludeFiles>%(ForcedIncludeFiles)</ForcedIncludeFiles>
+    </ClCompile>
+    <Lib>
+      <OutputFile>$(OutDir)$(ProjectName)-win32.lib</OutputFile>
+    </Lib>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Midl>
+      <TargetEnvironment>X64</TargetEnvironment>
+    </Midl>
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>../../src/mesa;../../src;../../include/c99;../../include;../../src/glsl;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;NOMINMAX;_CRT_SECURE_NO_WARNINGS;_CRT_SECURE_NO_DEPRECATE;__STDC_VERSION__=199901L;__STDC__;strdup=_strdup;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MinimalRebuild>false</MinimalRebuild>
+      <ExceptionHandling>
+      </ExceptionHandling>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <DisableSpecificWarnings>4996;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <ForcedIncludeFiles>%(ForcedIncludeFiles)</ForcedIncludeFiles>
+    </ClCompile>
+    <Lib>
+      <OutputFile>$(OutDir)$(ProjectName)-x64.lib</OutputFile>
+    </Lib>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <Optimization>MaxSpeed</Optimization>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <AdditionalIncludeDirectories>../../src/mesa;../../src;../../include/c99;../../include;../../src/glsl;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;NOMINMAX;_CRT_SECURE_NO_WARNINGS;_CRT_SECURE_NO_DEPRECATE;__STDC_VERSION__=199901L;__STDC__;strdup=_strdup;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>
+      </ExceptionHandling>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>OldStyle</DebugInformationFormat>
+      <DisableSpecificWarnings>4996;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <ForcedIncludeFiles>%(ForcedIncludeFiles)</ForcedIncludeFiles>
+    </ClCompile>
+    <Lib>
+      <OutputFile>$(OutDir)$(ProjectName)-win32.lib</OutputFile>
+    </Lib>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Midl>
+      <TargetEnvironment>X64</TargetEnvironment>
+    </Midl>
+    <ClCompile>
+      <Optimization>MaxSpeed</Optimization>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <AdditionalIncludeDirectories>../../src/mesa;../../src;../../include/c99;../../include;../../src/glsl;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;NOMINMAX;_CRT_SECURE_NO_WARNINGS;_CRT_SECURE_NO_DEPRECATE;__STDC_VERSION__=199901L;__STDC__;strdup=_strdup;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>
+      </ExceptionHandling>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <RuntimeTypeInfo>false</RuntimeTypeInfo>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>OldStyle</DebugInformationFormat>
+      <DisableSpecificWarnings>4996;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <ForcedIncludeFiles>%(ForcedIncludeFiles)</ForcedIncludeFiles>
+    </ClCompile>
+    <Lib>
+      <OutputFile>$(OutDir)$(ProjectName)-x64.lib</OutputFile>
+    </Lib>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\src\glsl\ast.h" />
+    <ClInclude Include="..\..\src\glsl\builtin_type_macros.h" />
+    <ClInclude Include="..\..\src\glsl\glsl_optimizer.h" />
+    <ClInclude Include="..\..\src\glsl\glsl_parser.h" />
+    <ClInclude Include="..\..\src\glsl\glsl_parser_extras.h" />
+    <ClInclude Include="..\..\src\glsl\glsl_symbol_table.h" />
+    <ClInclude Include="..\..\src\glsl\glsl_types.h" />
+    <ClInclude Include="..\..\src\glsl\ir.h" />
+    <ClInclude Include="..\..\src\glsl\ir_basic_block.h" />
+    <ClInclude Include="..\..\src\glsl\ir_builder.h" />
+    <ClInclude Include="..\..\src\glsl\ir_expression_flattening.h" />
+    <ClInclude Include="..\..\src\glsl\ir_function_inlining.h" />
+    <ClInclude Include="..\..\src\glsl\ir_hierarchical_visitor.h" />
+    <ClInclude Include="..\..\src\glsl\ir_optimization.h" />
+    <ClInclude Include="..\..\src\glsl\ir_print_glsl_visitor.h" />
+    <ClInclude Include="..\..\src\glsl\ir_print_metal_visitor.h" />
+    <ClInclude Include="..\..\src\glsl\ir_print_visitor.h" />
+    <ClInclude Include="..\..\src\glsl\ir_rvalue_visitor.h" />
+    <ClInclude Include="..\..\src\glsl\ir_stats.h" />
+    <ClInclude Include="..\..\src\glsl\ir_uniform.h" />
+    <ClInclude Include="..\..\src\glsl\ir_unused_structs.h" />
+    <ClInclude Include="..\..\src\glsl\ir_variable_refcount.h" />
+    <ClInclude Include="..\..\src\glsl\ir_visitor.h" />
+    <ClInclude Include="..\..\src\glsl\linker.h" />
+    <ClInclude Include="..\..\src\glsl\link_uniform_block_active_visitor.h" />
+    <ClInclude Include="..\..\src\glsl\link_varyings.h" />
+    <ClInclude Include="..\..\src\glsl\list.h" />
+    <ClInclude Include="..\..\src\glsl\loop_analysis.h" />
+    <ClInclude Include="..\..\src\glsl\program.h" />
+    <ClInclude Include="..\..\src\glsl\s_expression.h" />
+    <ClInclude Include="..\..\src\glsl\standalone_scaffolding.h" />
+    <ClInclude Include="..\..\src\glsl\strtod.h" />
+    <ClInclude Include="..\..\src\glsl\glcpp\glcpp-parse.h" />
+    <ClInclude Include="..\..\src\glsl\glcpp\glcpp.h" />
+    <ClInclude Include="..\..\src\mesa\program\hash_table.h" />
+    <ClInclude Include="..\..\src\mesa\program\prog_instruction.h" />
+    <ClInclude Include="..\..\src\mesa\program\prog_parameter.h" />
+    <ClInclude Include="..\..\src\mesa\program\prog_statevars.h" />
+    <ClInclude Include="..\..\src\mesa\program\symbol_table.h" />
+    <ClInclude Include="..\..\src\mesa\main\compiler.h" />
+    <ClInclude Include="..\..\src\mesa\main\config.h" />
+    <ClInclude Include="..\..\src\mesa\main\context.h" />
+    <ClInclude Include="..\..\src\mesa\main\core.h" />
+    <ClInclude Include="..\..\src\mesa\main\dd.h" />
+    <ClInclude Include="..\..\src\mesa\main\glheader.h" />
+    <ClInclude Include="..\..\src\mesa\main\glminimal.h" />
+    <ClInclude Include="..\..\src\mesa\main\imports.h" />
+    <ClInclude Include="..\..\src\mesa\main\macros.h" />
+    <ClInclude Include="..\..\src\mesa\main\mtypes.h" />
+    <ClInclude Include="..\..\src\mesa\main\simple_list.h" />
+    <ClInclude Include="..\..\src\util\hash_table.h" />
+    <ClInclude Include="..\..\src\util\ralloc.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\src\glsl\ast_array_index.cpp" />
+    <ClCompile Include="..\..\src\glsl\ast_expr.cpp" />
+    <ClCompile Include="..\..\src\glsl\ast_function.cpp" />
+    <ClCompile Include="..\..\src\glsl\ast_to_hir.cpp" />
+    <ClCompile Include="..\..\src\glsl\ast_type.cpp" />
+    <ClCompile Include="..\..\src\glsl\builtin_functions.cpp" />
+    <ClCompile Include="..\..\src\glsl\builtin_types.cpp" />
+    <ClCompile Include="..\..\src\glsl\builtin_variables.cpp" />
+    <ClCompile Include="..\..\src\glsl\glsl_lexer.cpp" />
+    <ClCompile Include="..\..\src\glsl\glsl_optimizer.cpp" />
+    <ClCompile Include="..\..\src\glsl\glsl_parser.cpp" />
+    <ClCompile Include="..\..\src\glsl\glsl_parser_extras.cpp" />
+    <ClCompile Include="..\..\src\glsl\glsl_symbol_table.cpp" />
+    <ClCompile Include="..\..\src\glsl\glsl_types.cpp" />
+    <ClCompile Include="..\..\src\glsl\hir_field_selection.cpp" />
+    <ClCompile Include="..\..\src\glsl\ir.cpp" />
+    <ClCompile Include="..\..\src\glsl\ir_basic_block.cpp" />
+    <ClCompile Include="..\..\src\glsl\ir_builder.cpp" />
+    <ClCompile Include="..\..\src\glsl\ir_clone.cpp" />
+    <ClCompile Include="..\..\src\glsl\ir_constant_expression.cpp" />
+    <ClCompile Include="..\..\src\glsl\ir_equals.cpp" />
+    <ClCompile Include="..\..\src\glsl\ir_expression_flattening.cpp" />
+    <ClCompile Include="..\..\src\glsl\ir_function.cpp" />
+    <ClCompile Include="..\..\src\glsl\ir_function_can_inline.cpp" />
+    <ClCompile Include="..\..\src\glsl\ir_function_detect_recursion.cpp" />
+    <ClCompile Include="..\..\src\glsl\ir_hierarchical_visitor.cpp" />
+    <ClCompile Include="..\..\src\glsl\ir_hv_accept.cpp" />
+    <ClCompile Include="..\..\src\glsl\ir_import_prototypes.cpp" />
+    <ClCompile Include="..\..\src\glsl\ir_print_glsl_visitor.cpp" />
+    <ClCompile Include="..\..\src\glsl\ir_print_metal_visitor.cpp" />
+    <ClCompile Include="..\..\src\glsl\ir_print_visitor.cpp" />
+    <ClCompile Include="..\..\src\glsl\ir_rvalue_visitor.cpp" />
+    <ClCompile Include="..\..\src\glsl\ir_stats.cpp" />
+    <ClCompile Include="..\..\src\glsl\ir_unused_structs.cpp" />
+    <ClCompile Include="..\..\src\glsl\ir_validate.cpp" />
+    <ClCompile Include="..\..\src\glsl\ir_variable_refcount.cpp" />
+    <ClCompile Include="..\..\src\glsl\link_atomics.cpp" />
+    <ClCompile Include="..\..\src\glsl\link_functions.cpp" />
+    <ClCompile Include="..\..\src\glsl\link_interface_blocks.cpp" />
+    <ClCompile Include="..\..\src\glsl\link_uniform_blocks.cpp" />
+    <ClCompile Include="..\..\src\glsl\link_uniform_block_active_visitor.cpp" />
+    <ClCompile Include="..\..\src\glsl\link_uniform_initializers.cpp" />
+    <ClCompile Include="..\..\src\glsl\link_uniforms.cpp" />
+    <ClCompile Include="..\..\src\glsl\linker.cpp" />
+    <ClCompile Include="..\..\src\glsl\link_varyings.cpp" />
+    <ClCompile Include="..\..\src\glsl\loop_analysis.cpp" />
+    <ClCompile Include="..\..\src\glsl\loop_controls.cpp" />
+    <ClCompile Include="..\..\src\glsl\loop_unroll.cpp" />
+    <ClCompile Include="..\..\src\glsl\lower_clip_distance.cpp" />
+    <ClCompile Include="..\..\src\glsl\lower_discard.cpp" />
+    <ClCompile Include="..\..\src\glsl\lower_discard_flow.cpp" />
+    <ClCompile Include="..\..\src\glsl\lower_if_to_cond_assign.cpp" />
+    <ClCompile Include="..\..\src\glsl\lower_instructions.cpp" />
+    <ClCompile Include="..\..\src\glsl\lower_jumps.cpp" />
+    <ClCompile Include="..\..\src\glsl\lower_mat_op_to_vec.cpp" />
+    <ClCompile Include="..\..\src\glsl\lower_named_interface_blocks.cpp" />
+    <ClCompile Include="..\..\src\glsl\lower_noise.cpp" />
+    <ClCompile Include="..\..\src\glsl\lower_offset_array.cpp" />
+    <ClCompile Include="..\..\src\glsl\lower_output_reads.cpp" />
+    <ClCompile Include="..\..\src\glsl\lower_packed_varyings.cpp" />
+    <ClCompile Include="..\..\src\glsl\lower_packing_builtins.cpp" />
+    <ClCompile Include="..\..\src\glsl\lower_ubo_reference.cpp" />
+    <ClCompile Include="..\..\src\glsl\lower_variable_index_to_cond_assign.cpp" />
+    <ClCompile Include="..\..\src\glsl\lower_vector_insert.cpp" />
+    <ClCompile Include="..\..\src\glsl\lower_vec_index_to_cond_assign.cpp" />
+    <ClCompile Include="..\..\src\glsl\lower_vec_index_to_swizzle.cpp" />
+    <ClCompile Include="..\..\src\glsl\lower_vector.cpp" />
+    <ClCompile Include="..\..\src\glsl\lower_vertex_id.cpp" />
+    <ClCompile Include="..\..\src\glsl\main.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\opt_algebraic.cpp" />
+    <ClCompile Include="..\..\src\glsl\opt_array_splitting.cpp" />
+    <ClCompile Include="..\..\src\glsl\opt_constant_folding.cpp" />
+    <ClCompile Include="..\..\src\glsl\opt_constant_propagation.cpp" />
+    <ClCompile Include="..\..\src\glsl\opt_constant_variable.cpp" />
+    <ClCompile Include="..\..\src\glsl\opt_copy_propagation.cpp" />
+    <ClCompile Include="..\..\src\glsl\opt_copy_propagation_elements.cpp" />
+    <ClCompile Include="..\..\src\glsl\opt_cse.cpp" />
+    <ClCompile Include="..\..\src\glsl\opt_dead_builtin_variables.cpp" />
+    <ClCompile Include="..\..\src\glsl\opt_dead_builtin_varyings.cpp" />
+    <ClCompile Include="..\..\src\glsl\opt_dead_code.cpp" />
+    <ClCompile Include="..\..\src\glsl\opt_dead_code_local.cpp" />
+    <ClCompile Include="..\..\src\glsl\opt_dead_functions.cpp" />
+    <ClCompile Include="..\..\src\glsl\opt_flatten_nested_if_blocks.cpp" />
+    <ClCompile Include="..\..\src\glsl\opt_flip_matrices.cpp" />
+    <ClCompile Include="..\..\src\glsl\opt_function_inlining.cpp" />
+    <ClCompile Include="..\..\src\glsl\opt_if_simplification.cpp" />
+    <ClCompile Include="..\..\src\glsl\opt_minmax.cpp" />
+    <ClCompile Include="..\..\src\glsl\opt_noop_swizzle.cpp" />
+    <ClCompile Include="..\..\src\glsl\opt_rebalance_tree.cpp" />
+    <ClCompile Include="..\..\src\glsl\opt_redundant_jumps.cpp" />
+    <ClCompile Include="..\..\src\glsl\opt_structure_splitting.cpp" />
+    <ClCompile Include="..\..\src\glsl\opt_swizzle_swizzle.cpp" />
+    <ClCompile Include="..\..\src\glsl\opt_tree_grafting.cpp" />
+    <ClCompile Include="..\..\src\glsl\opt_vectorize.cpp" />
+    <ClCompile Include="..\..\src\glsl\opt_vector_splitting.cpp" />
+    <ClCompile Include="..\..\src\glsl\s_expression.cpp" />
+    <ClCompile Include="..\..\src\glsl\standalone_scaffolding.cpp" />
+    <ClCompile Include="..\..\src\glsl\strtod.c" />
+    <ClCompile Include="..\..\src\glsl\glcpp\glcpp-lex.c" />
+    <ClCompile Include="..\..\src\glsl\glcpp\glcpp-parse.c" />
+    <ClCompile Include="..\..\src\glsl\glcpp\glcpp.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\glcpp\pp.c" />
+    <ClCompile Include="..\..\src\mesa\main\imports.c" />
+    <ClCompile Include="..\..\src\mesa\program\prog_hash_table.c" />
+    <ClCompile Include="..\..\src\mesa\program\symbol_table.c" />
+    <ClCompile Include="..\..\src\util\hash_table.c" />
+    <ClCompile Include="..\..\src\util\ralloc.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <CustomBuildStep Include="..\..\src\glsl\glsl_lexer.lpp">
+      <FileType>Document</FileType>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </CustomBuildStep>
+    <CustomBuildStep Include="..\..\src\glsl\glsl_parser.ypp">
+      <FileType>Document</FileType>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </CustomBuildStep>
+    <CustomBuildStep Include="..\..\src\glsl\glcpp\glcpp-lex.l">
+      <FileType>Document</FileType>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </CustomBuildStep>
+    <CustomBuildStep Include="..\..\src\glsl\glcpp\glcpp-parse.y">
+      <FileType>Document</FileType>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </CustomBuildStep>
+    <None Include="..\..\README.md" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/projects/vs2013/glsl_optimizer_lib.vcxproj.filters
+++ b/projects/vs2013/glsl_optimizer_lib.vcxproj.filters
@@ -1,0 +1,513 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="src">
+      <UniqueIdentifier>{95543dab-5f63-41a8-8860-7e1659edc0b2}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="src\glsl">
+      <UniqueIdentifier>{c4cf23cb-22b9-4496-9cf7-8b25dc1e405f}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="src\glsl\glcpp">
+      <UniqueIdentifier>{7ec0058a-15c6-427d-9fce-27af39000e81}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="src\mesa">
+      <UniqueIdentifier>{28f43e08-dfe8-424d-886c-db6e2ee33957}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="src\mesa\program">
+      <UniqueIdentifier>{fd238409-ea7e-4bbe-8566-d5b8e7330242}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="src\mesa\main">
+      <UniqueIdentifier>{b58605f3-8f5a-4800-838c-a0a04d1bdc96}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\src\glsl\ast.h">
+      <Filter>src\glsl</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\glsl\glsl_optimizer.h">
+      <Filter>src\glsl</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\glsl\glsl_parser.h">
+      <Filter>src\glsl</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\glsl\glsl_parser_extras.h">
+      <Filter>src\glsl</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\glsl\glsl_symbol_table.h">
+      <Filter>src\glsl</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\glsl\glsl_types.h">
+      <Filter>src\glsl</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\glsl\ir.h">
+      <Filter>src\glsl</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\glsl\ir_basic_block.h">
+      <Filter>src\glsl</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\glsl\ir_expression_flattening.h">
+      <Filter>src\glsl</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\glsl\ir_function_inlining.h">
+      <Filter>src\glsl</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\glsl\ir_hierarchical_visitor.h">
+      <Filter>src\glsl</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\glsl\ir_optimization.h">
+      <Filter>src\glsl</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\glsl\ir_print_glsl_visitor.h">
+      <Filter>src\glsl</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\glsl\ir_print_metal_visitor.h">
+      <Filter>src\glsl</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\glsl\ir_print_visitor.h">
+      <Filter>src\glsl</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\glsl\ir_rvalue_visitor.h">
+      <Filter>src\glsl</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\glsl\ir_unused_structs.h">
+      <Filter>src\glsl</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\glsl\ir_variable_refcount.h">
+      <Filter>src\glsl</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\glsl\ir_visitor.h">
+      <Filter>src\glsl</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\glsl\linker.h">
+      <Filter>src\glsl</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\glsl\list.h">
+      <Filter>src\glsl</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\glsl\loop_analysis.h">
+      <Filter>src\glsl</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\glsl\program.h">
+      <Filter>src\glsl</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\glsl\s_expression.h">
+      <Filter>src\glsl</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\glsl\standalone_scaffolding.h">
+      <Filter>src\glsl</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\glsl\strtod.h">
+      <Filter>src\glsl</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\glsl\glcpp\glcpp-parse.h">
+      <Filter>src\glsl\glcpp</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\glsl\glcpp\glcpp.h">
+      <Filter>src\glsl\glcpp</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mesa\program\prog_instruction.h">
+      <Filter>src\mesa\program</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mesa\program\prog_parameter.h">
+      <Filter>src\mesa\program</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mesa\program\prog_statevars.h">
+      <Filter>src\mesa\program</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mesa\program\symbol_table.h">
+      <Filter>src\mesa\program</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mesa\main\compiler.h">
+      <Filter>src\mesa\main</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mesa\main\config.h">
+      <Filter>src\mesa\main</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mesa\main\context.h">
+      <Filter>src\mesa\main</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mesa\main\core.h">
+      <Filter>src\mesa\main</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mesa\main\dd.h">
+      <Filter>src\mesa\main</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mesa\main\glheader.h">
+      <Filter>src\mesa\main</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mesa\main\glminimal.h">
+      <Filter>src\mesa\main</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mesa\main\imports.h">
+      <Filter>src\mesa\main</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mesa\main\macros.h">
+      <Filter>src\mesa\main</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mesa\main\mtypes.h">
+      <Filter>src\mesa\main</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mesa\main\simple_list.h">
+      <Filter>src\mesa\main</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\glsl\ir_uniform.h">
+      <Filter>src\glsl</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\mesa\program\hash_table.h">
+      <Filter>src\mesa\program</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\glsl\link_uniform_block_active_visitor.h">
+      <Filter>src\glsl</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\glsl\link_varyings.h">
+      <Filter>src\glsl</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\glsl\ir_builder.h">
+      <Filter>src\glsl</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\glsl\builtin_type_macros.h">
+      <Filter>src\glsl</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\glsl\ir_stats.h">
+      <Filter>src\glsl</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\util\hash_table.h" />
+    <ClInclude Include="..\..\src\util\ralloc.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\src\glsl\ast_expr.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\ast_function.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\ast_to_hir.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\ast_type.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\builtin_functions.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\builtin_variables.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\glsl_lexer.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\glsl_optimizer.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\glsl_parser.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\glsl_parser_extras.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\glsl_symbol_table.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\glsl_types.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\hir_field_selection.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\ir.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\ir_basic_block.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\ir_clone.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\ir_constant_expression.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\ir_equals.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\ir_expression_flattening.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\ir_function.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\ir_function_can_inline.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\ir_function_detect_recursion.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\ir_hierarchical_visitor.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\ir_hv_accept.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\ir_import_prototypes.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\ir_print_glsl_visitor.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\ir_print_metal_visitor.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\ir_print_visitor.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\ir_rvalue_visitor.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\ir_unused_structs.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\ir_validate.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\ir_variable_refcount.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\link_atomics.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\link_functions.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\link_uniform_initializers.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\link_uniforms.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\linker.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\loop_analysis.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\loop_controls.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\loop_unroll.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\lower_clip_distance.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\lower_discard.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\lower_discard_flow.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\lower_if_to_cond_assign.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\lower_instructions.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\lower_jumps.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\lower_mat_op_to_vec.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\lower_noise.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\lower_variable_index_to_cond_assign.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\lower_vec_index_to_cond_assign.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\lower_vec_index_to_swizzle.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\lower_vector.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\main.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\opt_algebraic.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\opt_array_splitting.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\opt_constant_folding.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\opt_constant_propagation.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\opt_constant_variable.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\opt_copy_propagation.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\opt_copy_propagation_elements.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\opt_cse.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\opt_dead_code.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\opt_dead_code_local.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\opt_dead_functions.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\opt_function_inlining.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\opt_if_simplification.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\opt_noop_swizzle.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\opt_redundant_jumps.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\opt_structure_splitting.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\opt_swizzle_swizzle.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\opt_tree_grafting.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\opt_vectorize.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\s_expression.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\standalone_scaffolding.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\strtod.c">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\glcpp\glcpp-lex.c">
+      <Filter>src\glsl\glcpp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\glcpp\glcpp-parse.c">
+      <Filter>src\glsl\glcpp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\glcpp\glcpp.c">
+      <Filter>src\glsl\glcpp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\glcpp\pp.c">
+      <Filter>src\glsl\glcpp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\mesa\program\symbol_table.c">
+      <Filter>src\mesa\program</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\mesa\main\imports.c">
+      <Filter>src\mesa\main</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\mesa\program\prog_hash_table.c">
+      <Filter>src\mesa\program</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\ast_array_index.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\link_uniform_block_active_visitor.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\link_uniform_blocks.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\link_varyings.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\opt_flatten_nested_if_blocks.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\ir_builder.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\lower_packed_varyings.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\lower_packing_builtins.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\link_interface_blocks.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\lower_named_interface_blocks.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\lower_offset_array.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\lower_output_reads.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\lower_ubo_reference.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\lower_vector_insert.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\lower_vertex_id.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\builtin_types.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\opt_dead_builtin_variables.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\opt_minmax.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\opt_rebalance_tree.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\opt_dead_builtin_varyings.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\opt_flip_matrices.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\ir_stats.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\glsl\opt_vector_splitting.cpp">
+      <Filter>src\glsl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\util\hash_table.c" />
+    <ClCompile Include="..\..\src\util\ralloc.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\..\README.md" />
+  </ItemGroup>
+  <ItemGroup>
+    <CustomBuildStep Include="..\..\src\glsl\glsl_lexer.lpp">
+      <Filter>src\glsl</Filter>
+    </CustomBuildStep>
+    <CustomBuildStep Include="..\..\src\glsl\glsl_parser.ypp">
+      <Filter>src\glsl</Filter>
+    </CustomBuildStep>
+    <CustomBuildStep Include="..\..\src\glsl\glcpp\glcpp-lex.l">
+      <Filter>src\glsl\glcpp</Filter>
+    </CustomBuildStep>
+    <CustomBuildStep Include="..\..\src\glsl\glcpp\glcpp-parse.y">
+      <Filter>src\glsl\glcpp</Filter>
+    </CustomBuildStep>
+  </ItemGroup>
+</Project>

--- a/projects/vs2013/glsl_optimizer_tests.vcxproj
+++ b/projects/vs2013/glsl_optimizer_tests.vcxproj
@@ -1,0 +1,190 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{BB382242-6EBB-445F-989C-B9BA61D17965}</ProjectGuid>
+    <RootNamespace>glsl_optimizer_tests</RootNamespace>
+    <Keyword>Win32Proj</Keyword>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
+    <PlatformToolset>v120</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v120</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
+    <PlatformToolset>v120</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v120</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">build/$(ProjectName)/$(Configuration)\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">build/$(ProjectName)/$(Configuration)\</IntDir>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</LinkIncremental>
+    <GenerateManifest Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</GenerateManifest>
+    <EmbedManifest Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</EmbedManifest>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">build/$(ProjectName)/$(Platform)/$(Configuration)\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">build/$(ProjectName)/$(Platform)/$(Configuration)\</IntDir>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</LinkIncremental>
+    <GenerateManifest Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</GenerateManifest>
+    <EmbedManifest Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</EmbedManifest>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">build/$(ProjectName)/$(Configuration)\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">build/$(ProjectName)/$(Configuration)\</IntDir>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</LinkIncremental>
+    <GenerateManifest Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</GenerateManifest>
+    <EmbedManifest Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</EmbedManifest>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|x64'">build/$(ProjectName)/$(Platform)/$(Configuration)\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|x64'">build/$(ProjectName)/$(Platform)/$(Configuration)\</IntDir>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</LinkIncremental>
+    <GenerateManifest Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</GenerateManifest>
+    <EmbedManifest Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</EmbedManifest>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MinimalRebuild>false</MinimalRebuild>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>opengl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Console</SubSystem>
+      <TargetMachine>MachineX86</TargetMachine>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Midl>
+      <TargetEnvironment>X64</TargetEnvironment>
+    </Midl>
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MinimalRebuild>false</MinimalRebuild>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>opengl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Console</SubSystem>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <Optimization>MaxSpeed</Optimization>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>opengl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Console</SubSystem>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <TargetMachine>MachineX86</TargetMachine>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Midl>
+      <TargetEnvironment>X64</TargetEnvironment>
+    </Midl>
+    <ClCompile>
+      <Optimization>MaxSpeed</Optimization>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>opengl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Console</SubSystem>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ProjectReference Include="glsl_optimizer_lib.vcxproj">
+      <Project>{b475a403-9d9b-410d-8a93-ba49fc4dd811}</Project>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\tests\glsl_optimizer_tests.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/src/glsl/ir_print_glsl_visitor.cpp
+++ b/src/glsl/ir_print_glsl_visitor.cpp
@@ -31,6 +31,8 @@
 #include <math.h>
 #include <limits>
 
+static const char* processed_uniform_blocks[64] = { 0 };
+static int   num_uniform_blocks = 0;
 
 static void print_type(string_buffer& buffer, const glsl_type *t, bool arraySize);
 static void print_type_post(string_buffer& buffer, const glsl_type *t, bool arraySize);
@@ -105,7 +107,7 @@ public:
 	void end_statement_line();
 	void newline_deindent();
 	void print_var_name (ir_variable* v);
-	void print_precision (ir_instruction* ir, const glsl_type* type);
+  void print_precision( ir_instruction* ir, const glsl_type* type, glsl_precision=glsl_precision_undefined );
 
 	virtual void visit(ir_variable *);
 	virtual void visit(ir_function_signature *);
@@ -129,10 +131,14 @@ public:
 	virtual void visit(ir_emit_vertex *);
 	virtual void visit(ir_end_primitive *);
 	
+  void visit_uniform_block( ir_variable* );
+
 	void emit_assignment_part (ir_dereference* lhs, ir_rvalue* rhs, unsigned write_mask, ir_rvalue* dstIndex);
     bool can_emit_canonical_for (loop_variable_state *ls);
 	bool emit_canonical_for (ir_loop* ir);
 	bool try_print_array_assignment (ir_dereference* lhs, ir_rvalue* rhs);
+
+
 	
 	int indentation;
 	int expression_depth;
@@ -154,6 +160,9 @@ _mesa_print_ir_glsl(exec_list *instructions,
 		char* buffer, PrintGlslMode mode)
 {
 	string_buffer str(buffer);
+
+  num_uniform_blocks = 0;
+  memset( processed_uniform_blocks, 0, sizeof( processed_uniform_blocks ) );
 
 	// print version & extensions
 	if (state) {
@@ -273,7 +282,7 @@ void ir_print_glsl_visitor::print_var_name (ir_variable* v)
 	}
 }
 
-void ir_print_glsl_visitor::print_precision (ir_instruction* ir, const glsl_type* type)
+void ir_print_glsl_visitor::print_precision (ir_instruction* ir, const glsl_type* type, glsl_precision prec)
 {
 	if (!this->use_precision)
 		return;
@@ -285,7 +294,8 @@ void ir_print_glsl_visitor::print_precision (ir_instruction* ir, const glsl_type
 	{
 		return;
 	}
-	glsl_precision prec = precision_from_ir(ir);
+
+	if ( ir ) prec = precision_from_ir(ir);
 	
 	// In fragment shader, default float precision is undefined.
 	// We must thus always print it, when there was no default precision
@@ -309,7 +319,7 @@ void ir_print_glsl_visitor::print_precision (ir_instruction* ir, const glsl_type
 	
 	if (prec == glsl_precision_high || prec == glsl_precision_undefined)
 	{
-		if (ir->ir_type == ir_type_function_signature)
+		if (ir && ir->ir_type == ir_type_function_signature)
 			return;
 	}
 	buffer.asprintf_append ("%s", get_precision_string(prec));
@@ -338,9 +348,71 @@ static void print_type_post(string_buffer& buffer, const glsl_type *t, bool arra
 	}
 }
 
+void ir_print_glsl_visitor::visit_uniform_block( ir_variable* ir )
+{
+  const glsl_type* itype = ir->get_interface_type();
+
+  for ( int i = 0; i < num_uniform_blocks; i++ )
+  {
+    if ( itype->name == processed_uniform_blocks[i] )
+    {
+      skipped_this_ir = true;
+      return;
+    }
+  }
+
+  assert( num_uniform_blocks < sizeof( processed_uniform_blocks ) / sizeof( processed_uniform_blocks[0] ) );
+
+  processed_uniform_blocks[num_uniform_blocks++] = itype->name;
+
+  const char* packing = nullptr;
+
+  switch ( itype->interface_packing )
+  {
+  case GLSL_INTERFACE_PACKING_STD140: packing = "std140"; break;
+  case GLSL_INTERFACE_PACKING_SHARED: packing = "shared"; break;
+  default: packing = nullptr;  break;
+  }
+
+  // TODO: handle explicit locations and bindings within layout expression for uniform blocks.
+  // that does not appear to be getting preserved.
+  if ( packing )
+  {
+    buffer.asprintf_append( "layout(%s) ", packing );
+  }
+
+  buffer.asprintf_append( "uniform %s {\n", itype->name );
+
+  for ( unsigned int i = 0; i < itype->length; i++ )
+  {
+    const glsl_type* field_type = itype->fields.structure[i].type;
+    const char* field_name = itype->fields.structure[i].name;
+    const glsl_precision field_precision = itype->fields.structure[i].precision;
+
+    buffer.asprintf_append( "  " );
+    print_precision( nullptr, field_type, field_precision );
+    print_type( buffer, field_type, false );
+    buffer.asprintf_append( " %s", field_name );
+    print_type_post( buffer, field_type, false );
+    buffer.asprintf_append( ";\n" );
+  }
+
+  buffer.asprintf_append( "}" );
+
+  if ( ir->is_interface_instance() )
+  {
+    buffer.asprintf_append( " %s", ir->name );
+  }
+}
 
 void ir_print_glsl_visitor::visit(ir_variable *ir)
 {
+  if ( ir->is_interface_instance() || ir->is_in_uniform_block() )
+  {
+    visit_uniform_block( ir );
+    return;
+  }
+
 	const char *const cent = (ir->data.centroid) ? "centroid " : "";
 	const char *const inv = (ir->data.invariant) ? "invariant " : "";
 	const char *const mode[3][ir_var_mode_count] =


### PR DESCRIPTION
handles layout packing specification

does not handle explicit layout block location or binding (this does not appear to be available in the high level intermediate representation of interface block type. that information is in the 'data' member of an ir_variable node only, it appears.

also added vs2013 projects.