### PR TITLE
Fix cmake build issues

### DIFF
--- a/contrib/glslopt/Main.cpp
+++ b/contrib/glslopt/Main.cpp
@@ -4,6 +4,12 @@
 #include <stdlib.h>
 #include "glsl_optimizer.h"
 
+extern "C" void
+_mesa_error_no_memory(const char *caller)
+{
+   fprintf(stderr, "Mesa error: out of memory in %s", caller);
+}
+
 static glslopt_ctx* gContext = 0;
 
 static int printhelp(const char* msg)

--- a/src/glsl/standalone_scaffolding.cpp
+++ b/src/glsl/standalone_scaffolding.cpp
@@ -50,10 +50,7 @@ _mesa_shader_debug(struct gl_context *, GLenum, GLuint *id,
 }
 
 extern "C" void
-_mesa_error_no_memory(const char *caller)
-{
-}
-
+_mesa_error_no_memory(const char *caller);
 
 struct gl_shader *
 _mesa_new_shader(struct gl_context *ctx, GLuint name, GLenum type)

--- a/tests/glsl_optimizer_tests.cpp
+++ b/tests/glsl_optimizer_tests.cpp
@@ -1,7 +1,9 @@
+#include <cstdlib>
 #include <string>
 #include <vector>
 #include <time.h>
 #include "../src/glsl/glsl_optimizer.h"
+
 
 #define GL_GLEXT_PROTOTYPES 1
 

--- a/tests/glsl_optimizer_tests.cpp
+++ b/tests/glsl_optimizer_tests.cpp
@@ -1,8 +1,15 @@
+#include <cstdio>
 #include <cstdlib>
 #include <string>
 #include <vector>
 #include <time.h>
 #include "../src/glsl/glsl_optimizer.h"
+
+extern "C" void
+_mesa_error_no_memory(const char *caller)
+{
+   fprintf(stderr, "Mesa error: out of memory in %s", caller);
+}
 
 
 #define GL_GLEXT_PROTOTYPES 1


### PR DESCRIPTION
There were both compiler and linker errors using CMake on both Linux and OSX.   This changeset fixes them.  Compiles, builds, and tests successfully on OSX (cmake and Xcode).   Compiles and builds on  Linux.