### PR TITLE
Prevent variables being incorrectly identified as loop inductors

### DIFF
--- a/src/glsl/loop_analysis.cpp
+++ b/src/glsl/loop_analysis.cpp
@@ -28,6 +28,8 @@
 
 static bool is_loop_terminator(ir_if *ir);
 
+static bool used_outside_loops(exec_node *head, ir_variable *var, bool first_assignment);
+
 static bool all_expression_operands_are_loop_constant(ir_rvalue *,
 						      hash_table *);
 
@@ -121,13 +123,20 @@ loop_state::get_for_inductor(const ir_variable *ir)
 }
 
 void
+loop_state::insert_non_inductor(ir_variable *var)
+{
+	// key doesn't matter, just needs to be non-NULL
+	hash_table_insert(this->ht_non_inductors, this, var);
+}
+
+bool
 loop_state::insert_inductor(loop_variable* loopvar, loop_variable_state* state, ir_loop* loop)
 {
 	ir_variable* var = loopvar->var;
 
 	// Check if this variable is already marked as "sure can't be a private inductor variable"
 	if (hash_table_find(this->ht_non_inductors, var))
-		return;
+		return false;
 
 	// Check if this variable is used after the loop anywhere. If it is, it can't be a
 	// variable that's private to the loop.
@@ -143,7 +152,7 @@ loop_state::insert_inductor(loop_variable* loopvar, loop_variable_state* state, 
 			// add to list of "non inductors", so that next loop does not try
 			// to add it as inductor again
 			hash_table_insert(this->ht_non_inductors, state, var);
-			return;
+			return false;
 		}
 	}
 
@@ -166,12 +175,13 @@ loop_state::insert_inductor(loop_variable* loopvar, loop_variable_state* state, 
 			// add to list of "non inductors", so that next loop does not try
 			// to add it as inductor again
 			hash_table_insert(this->ht_non_inductors, state, var);
-			return;
+			return false;
 		}
 	}
 	
 	state->private_induction_variable_count++;
 	hash_table_insert(this->ht_inductors, state, var);
+	return true;
 }
 
 
@@ -245,6 +255,8 @@ public:
    virtual ir_visitor_status visit(ir_loop_jump *);
    virtual ir_visitor_status visit(ir_dereference_variable *);
 
+   virtual ir_visitor_status visit(ir_variable *);
+
    virtual ir_visitor_status visit_enter(ir_call *);
 
    virtual ir_visitor_status visit_enter(ir_loop *);
@@ -287,6 +299,28 @@ loop_analysis::visit(ir_loop_jump *ir)
    return visit_continue;
 }
 
+
+ir_visitor_status
+loop_analysis::visit(ir_variable *var)
+{
+	// if inside a loop, simply continue - we're only interested in variables declared
+	// entirely outside of any loops
+	if (!this->state.is_empty())
+		return visit_continue;
+
+	// Check if this variable is used outside a loop anywhere. If it is, it can't be a
+	// variable that's private to the loop, so can't be an inductor.
+	// This doesn't reject all possible non-inductors, notably anything declared in an
+	// outer loop that isn't an inductor in an inner loop, but it can eliminate some
+	// problem cases
+	if (used_outside_loops(var->next, var, false))
+	{
+		// add to list of "non inductors"
+		loops->insert_non_inductor(var);
+	}
+
+	return visit_continue;
+}
 
 ir_visitor_status
 loop_analysis::visit_enter(ir_call *)
@@ -451,11 +485,12 @@ loop_analysis::visit_leave(ir_loop *ir)
       ir_rvalue *const inc =
 	 get_basic_induction_increment(lv->first_assignment, ls->var_hash);
       if (inc != NULL) {
-	 lv->increment = inc;
+         lv->increment = inc;
 
-	 lv->remove();
-	 ls->induction_variables.push_tail(lv);
-	 loops->insert_inductor(lv, ls, ir);
+         if (loops->insert_inductor(lv, ls, ir)) {
+            lv->remove();
+            ls->induction_variables.push_tail(lv);
+         }
       }
    }
 
@@ -696,6 +731,65 @@ is_loop_terminator(ir_if *ir)
       return false;
 
    return true;
+}
+
+
+bool
+used_outside_loops(exec_node *head, ir_variable *var, bool first_assignment)
+{
+	ir_variable_refcount_visitor refs;
+	for (exec_node* node = head;
+		 !node->is_tail_sentinel();
+		 node = node->next)
+	{
+		ir_instruction *ir = (ir_instruction *) node;
+		if (ir->ir_type == ir_type_variable)
+			continue;
+
+		// ignore the first assignment
+		if (!first_assignment && ir->ir_type == ir_type_assignment)
+		{
+			ir_assignment *assign = ir->as_assignment();
+			ir_variable *assignee = assign->lhs->whole_variable_referenced();
+
+			if(assignee == var)
+			{
+				first_assignment = true;
+				continue;
+			}
+		}
+
+		// we don't want to recurse into loops
+		if (ir->ir_type == ir_type_loop)
+			continue;
+
+		// recurse only for if statements, the other case we would need to recurse is
+		// loops, but we are looking for uses outside of loops.
+		if (ir->ir_type == ir_type_if)
+		{
+			ir_if *irif = ir->as_if();
+			if (used_outside_loops(irif->then_instructions.head, var, first_assignment))
+				return true;
+			if (used_outside_loops(irif->else_instructions.head, var, first_assignment))
+				return true;
+
+			// if we didn't find in each branch with our recursion, skip
+			// otherwise the accept (&refs) below will recurse into loops
+			// and may give a false positive.
+			continue;
+		}
+
+		// we know that we're not inside a loop as we haven't recursed inside,
+		// and we started outside of a loop, so any references to this variable
+		// mean it is used outside of any loops
+		ir->accept (&refs);
+		if (refs.find_variable_entry(var))
+		{
+			return true;
+		}
+	}
+
+	return false;
 }
 
 

--- a/src/glsl/loop_analysis.h
+++ b/src/glsl/loop_analysis.h
@@ -248,7 +248,8 @@ public:
    loop_variable_state *insert(ir_loop *ir);
 	
    loop_variable_state* get_for_inductor (const ir_variable*);
-   void insert_inductor(loop_variable* loopvar, loop_variable_state* state, ir_loop* loop);
+   bool insert_inductor(loop_variable* loopvar, loop_variable_state* state, ir_loop* loop);
+   void insert_non_inductor(ir_variable *var);
 
    bool loop_found;
 

--- a/tests/fragment/ast-out.txt
+++ b/tests/fragment/ast-out.txt
@@ -5,7 +5,8 @@ void main ()
     discard;
   };
   a_2 = 4.0;
-  for (int i_1 = 0; i_1 < 10; i_1++, a_2 += 1.0) {
+  for (int i_1 = 0; i_1 < 10; i_1++) {
+    a_2 += 1.0;
   };
   while (true) {
     a_2 += 2.0;

--- a/tests/fragment/ast-outES3.txt
+++ b/tests/fragment/ast-outES3.txt
@@ -7,7 +7,8 @@ void main ()
     discard;
   };
   a_2 = 4.0;
-  for (highp int i_1 = 0; i_1 < 10; i_1++, a_2 += 1.0) {
+  for (highp int i_1 = 0; i_1 < 10; i_1++) {
+    a_2 += 1.0;
   };
   while (true) {
     a_2 += 2.0;

--- a/tests/fragment/ast-outES3Metal.txt
+++ b/tests/fragment/ast-outES3Metal.txt
@@ -16,7 +16,8 @@ fragment xlatMtlShaderOutput xlatMtlMain (xlatMtlShaderInput _mtl_i [[stage_in]]
     discard_fragment();
   };
   a_2 = 4.0;
-  for (int i_1 = 0; i_1 < 10; i_1++, a_2 += 1.0) {
+  for (int i_1 = 0; i_1 < 10; i_1++) {
+    a_2 += 1.0;
   };
   while (true) {
     a_2 += 2.0;

--- a/tests/fragment/bug-loop-share-index-out.txt
+++ b/tests/fragment/bug-loop-share-index-out.txt
@@ -5,16 +5,24 @@ void main ()
   int myIdx_2;
   r_1 = vec4(0.0, 0.0, 0.0, 0.0);
   myIdx_2 = 1;
-  for (; myIdx_2 < loopNum; myIdx_2++) {
+  while (true) {
+    if ((myIdx_2 >= loopNum)) {
+      break;
+    };
     r_1.x = (r_1.x + 1.0);
     r_1.y = (r_1.y + 2.0);
     r_1.z = (r_1.z + 3.0);
+    myIdx_2++;
   };
   myIdx_2 = 2;
-  for (; myIdx_2 < loopNum; myIdx_2++) {
+  while (true) {
+    if ((myIdx_2 >= loopNum)) {
+      break;
+    };
     r_1.x = (r_1.x + 1.0);
     r_1.y = (r_1.y + 2.0);
     r_1.z = (r_1.z + 3.0);
+    myIdx_2++;
   };
   gl_FragColor = r_1;
 }

--- a/tests/fragment/loop-foraliasinductor-inES.txt
+++ b/tests/fragment/loop-foraliasinductor-inES.txt
@@ -1,0 +1,29 @@
+struct v2f {
+    highp vec2 uv;
+    highp vec3 nl;
+};
+uniform sampler2D _MainTex;
+uniform highp vec4 _TerrainTreeLightColors[4];
+lowp vec4 xlat_main (in v2f i) {
+    lowp vec4 col = texture2D( _MainTex, i.uv);
+    mediump vec3 light = vec3(0.0);
+    if(col.x >= 0.0) {
+        for (float j = 0.0; (j < i.uv.x); (j++)) {
+            light += col.xyz;
+        }
+    }
+    if(col.x >= 1.0) {
+         float j = i.uv.y;
+         j *= sin(j);
+         light += col.xyz*j;
+    }
+    return vec4(light, 1.0);
+}
+varying highp vec2 xlv_uv;
+varying highp vec3 xlv_nl;
+void main() {
+    v2f i;
+    i.uv = xlv_uv;
+    i.nl = xlv_nl;
+    gl_FragData[0] = xlat_main(i);
+}

--- a/tests/fragment/loop-foraliasinductor-outES.txt
+++ b/tests/fragment/loop-foraliasinductor-outES.txt
@@ -1,0 +1,36 @@
+uniform sampler2D _MainTex;
+varying highp vec2 xlv_uv;
+void main ()
+{
+  lowp vec4 tmpvar_1;
+  highp vec2 tmpvar_2;
+  tmpvar_2 = xlv_uv;
+  mediump vec3 light_3;
+  lowp vec4 col_4;
+  lowp vec4 tmpvar_5;
+  tmpvar_5 = texture2D (_MainTex, xlv_uv);
+  col_4 = tmpvar_5;
+  light_3 = vec3(0.0, 0.0, 0.0);
+  if ((tmpvar_5.x >= 0.0)) {
+    for (highp float j_6 = 0.0; j_6 < tmpvar_2.x; j_6 += 1.0) {
+      light_3 = (light_3 + col_4.xyz);
+    };
+  };
+  if ((tmpvar_5.x >= 1.0)) {
+    highp float j_7;
+    j_7 = (xlv_uv.y * sin(xlv_uv.y));
+    light_3 = (light_3 + (tmpvar_5.xyz * j_7));
+  };
+  mediump vec4 tmpvar_8;
+  tmpvar_8.w = 1.0;
+  tmpvar_8.xyz = light_3;
+  tmpvar_1 = tmpvar_8;
+  gl_FragData[0] = tmpvar_1;
+}
+
+
+// stats: 12 alu 1 tex 4 flow
+// inputs: 1
+//  #0: xlv_uv (high float) 2x1 [-1]
+// textures: 1
+//  #0: _MainTex (low 2d) 0x0 [-1]

--- a/tests/fragment/loop-forwronginductor-inES.txt
+++ b/tests/fragment/loop-forwronginductor-inES.txt
@@ -1,0 +1,24 @@
+struct v2f {
+    highp vec2 uv;
+    highp vec3 nl;
+};
+uniform sampler2D _MainTex;
+uniform highp vec4 _TerrainTreeLightColors[4];
+lowp vec4 xlat_main (in v2f i) {
+    lowp vec4 col = texture2D( _MainTex, i.uv);
+    mediump vec3 light = vec3(0.0);
+    if(col.x >= 0.0) {
+        for (float j = 0.0; (j < i.uv.x); (j++)) {
+            light += col.xyz;
+        }
+    }
+    return vec4(light, 1.0);
+}
+varying highp vec2 xlv_uv;
+varying highp vec3 xlv_nl;
+void main() {
+    v2f i;
+    i.uv = xlv_uv;
+    i.nl = xlv_nl;
+    gl_FragData[0] = xlat_main(i);
+}

--- a/tests/fragment/loop-forwronginductor-outES.txt
+++ b/tests/fragment/loop-forwronginductor-outES.txt
@@ -1,0 +1,31 @@
+uniform sampler2D _MainTex;
+varying highp vec2 xlv_uv;
+void main ()
+{
+  lowp vec4 tmpvar_1;
+  highp vec2 tmpvar_2;
+  tmpvar_2 = xlv_uv;
+  mediump vec3 light_3;
+  lowp vec4 col_4;
+  lowp vec4 tmpvar_5;
+  tmpvar_5 = texture2D (_MainTex, xlv_uv);
+  col_4 = tmpvar_5;
+  light_3 = vec3(0.0, 0.0, 0.0);
+  if ((tmpvar_5.x >= 0.0)) {
+    for (highp float j_6 = 0.0; j_6 < tmpvar_2.x; j_6 += 1.0) {
+      light_3 = (light_3 + col_4.xyz);
+    };
+  };
+  mediump vec4 tmpvar_7;
+  tmpvar_7.w = 1.0;
+  tmpvar_7.xyz = light_3;
+  tmpvar_1 = tmpvar_7;
+  gl_FragData[0] = tmpvar_1;
+}
+
+
+// stats: 7 alu 1 tex 3 flow
+// inputs: 1
+//  #0: xlv_uv (high float) 2x1 [-1]
+// textures: 1
+//  #0: _MainTex (low 2d) 0x0 [-1]

--- a/tests/fragment/opt-movevars-sideeffect2-outES.txt
+++ b/tests/fragment/opt-movevars-sideeffect2-outES.txt
@@ -12,7 +12,8 @@ void main ()
     discard;
   };
   c_1 = 0.0;
-  for (highp int i_2 = tmpvar_3; i_2 < 4; i_2++, c_1 = (c_1 + xx)) {
+  for (highp int i_2 = tmpvar_3; i_2 < 4; i_2++) {
+    c_1 = (c_1 + xx);
   };
   lowp vec4 tmpvar_4;
   tmpvar_4 = vec4(c_1);

--- a/tests/vertex/loops-for-withvec4inductorW-outES3.txt
+++ b/tests/vertex/loops-for-withvec4inductorW-outES3.txt
@@ -40,7 +40,10 @@ void main ()
   Temp_int_1.xyz = floatBitsToInt((intBitsToFloat(Temp_int_0).www * intBitsToFloat(Temp_int_1).xyz));
   Temp_2.xyz = glstate_lightmodel_ambient.xyz;
   Temp_int_0.w = 0;
-  for (; Temp_int_0.w < 4; Temp_int_0.w = (Temp_int_0.w + 1)) {
+  while (true) {
+    if ((Temp_int_0.w >= 4)) {
+      break;
+    };
     Temp_3.xyz = ((-(
       intBitsToFloat(Temp_int_0)
     .xyz) * unity_LightPosition[Temp_int_0.w].www) + unity_LightPosition[Temp_int_0.w].xyz);
@@ -61,6 +64,7 @@ void main ()
     Temp_2.w = max (Temp_2.w, 0.0);
     Temp_int_1.w = floatBitsToInt((intBitsToFloat(Temp_int_1).w * Temp_2.w));
     Temp_2.xyz = ((unity_LightColor[Temp_int_0.w].xyz * intBitsToFloat(Temp_int_1).www) + Temp_2.xyz);
+    Temp_int_0.w = (Temp_int_0.w + 1);
   };
   COLOR0.xyz = (Temp_2.xyz * _Color.xyz);
   COLOR0.w = (_Color.w * _ReflectColor.w);

--- a/tests/vertex/loops-for-withvec4inductorW-outES3Metal.txt
+++ b/tests/vertex/loops-for-withvec4inductorW-outES3Metal.txt
@@ -49,7 +49,10 @@ int4 Temp_int_1_5;
   Temp_int_1_5.xyz = as_type<int3>((as_type<float4>(Temp_int_0_4).www * as_type<float4>(Temp_int_1_5).xyz));
   Temp_2_2.xyz = _mtl_u.glstate_lightmodel_ambient.xyz;
   Temp_int_0_4.w = 0;
-  for (; Temp_int_0_4.w < 4; Temp_int_0_4.w = (Temp_int_0_4.w + 1)) {
+  while (true) {
+    if ((Temp_int_0_4.w >= 4)) {
+      break;
+    };
     Temp_3_3.xyz = ((-(
       as_type<float4>(Temp_int_0_4)
     .xyz) * _mtl_u.unity_LightPosition[Temp_int_0_4.w].www) + _mtl_u.unity_LightPosition[Temp_int_0_4.w].xyz);
@@ -70,6 +73,7 @@ int4 Temp_int_1_5;
     Temp_2_2.w = max (Temp_2_2.w, 0.0);
     Temp_int_1_5.w = as_type<int>((as_type<float4>(Temp_int_1_5).w * Temp_2_2.w));
     Temp_2_2.xyz = ((_mtl_u.unity_LightColor[Temp_int_0_4.w].xyz * as_type<float4>(Temp_int_1_5).www) + Temp_2_2.xyz);
+    Temp_int_0_4.w = (Temp_int_0_4.w + 1);
   };
   _mtl_o.COLOR0.xyz = (Temp_2_2.xyz * _mtl_u._Color.xyz);
   _mtl_o.COLOR0.w = (_mtl_u._Color.w * _mtl_u._ReflectColor.w);


### PR DESCRIPTION
If a variable is used outside loops we decide it's not an inductor -
this prevents variables incremented inside loops being made inductors
(potentially changing semantics if the increment is moved over a read).