### PR TITLE
The cure for the weirdest bugs.

### DIFF
--- a/src/glsl/list.h
+++ b/src/glsl/list.h
@@ -305,9 +305,9 @@ struct exec_node;
 #endif
 
 struct exec_list {
-   struct exec_node *head;
-   struct exec_node *tail;
-   struct exec_node *tail_pred;
+   struct exec_node * volatile head;
+   struct exec_node *          tail;
+   struct exec_node * volatile tail_pred;
 
 #ifdef __cplusplus
    DECLARE_RALLOC_CXX_OPERATORS(exec_list)


### PR DESCRIPTION
This PR prevents crashes with default optimizations (that is, assuming strict aliasing rules - no `-fno-strict-aliasing` given on a GCC-compatible command line).

See https://bugs.freedesktop.org/show_bug.cgi?id=91320
