### PR TITLE
Fixed VS2015 warnings while implicitly casting GLboolean <-> bool

### DIFF
--- a/src/glsl/glsl_optimizer.cpp
+++ b/src/glsl/glsl_optimizer.cpp
@@ -477,7 +477,7 @@ static void do_optimization_passes(exec_list* ir, bool linked, _mesa_glsl_parse_
 		progress2 = do_minmax_prune(ir); progress |= progress2; if (progress2) debug_print_ir ("After minmax prune", ir, state, mem_ctx);
 		progress2 = do_cse(ir); progress |= progress2; if (progress2) debug_print_ir ("After CSE", ir, state, mem_ctx);
 		progress2 = do_rebalance_tree(ir); progress |= progress2; if (progress2) debug_print_ir ("After rebalance tree", ir, state, mem_ctx);
-		progress2 = do_algebraic(ir, state->ctx->Const.NativeIntegers, &state->ctx->Const.ShaderCompilerOptions[state->stage]); progress |= progress2; if (progress2) debug_print_ir ("After algebraic", ir, state, mem_ctx);
+		progress2 = do_algebraic(ir, state->ctx->Const.NativeIntegers != GL_FALSE, &state->ctx->Const.ShaderCompilerOptions[state->stage]); progress |= progress2; if (progress2) debug_print_ir ("After algebraic", ir, state, mem_ctx);
 		progress2 = do_lower_jumps(ir); progress |= progress2; if (progress2) debug_print_ir ("After lower jumps", ir, state, mem_ctx);
 		progress2 = do_vec_index_to_swizzle(ir); progress |= progress2; if (progress2) debug_print_ir ("After vec index to swizzle", ir, state, mem_ctx);
 		progress2 = lower_vector_insert(ir, false); progress |= progress2; if (progress2) debug_print_ir ("After lower vector insert", ir, state, mem_ctx);

--- a/src/glsl/glsl_parser_extras.cpp
+++ b/src/glsl/glsl_parser_extras.cpp
@@ -214,7 +214,7 @@ _mesa_glsl_parse_state::_mesa_glsl_parse_state(struct gl_context *_ctx,
    memset(this->atomic_counter_offsets, 0,
           sizeof(this->atomic_counter_offsets));
    this->allow_extension_directive_midshader =
-      ctx->Const.AllowGLSLExtensionDirectiveMidShader;
+      ctx->Const.AllowGLSLExtensionDirectiveMidShader != GL_FALSE;
 }
 
 /**
@@ -1494,7 +1494,7 @@ _mesa_glsl_compile_shader(struct gl_context *ctx, struct gl_shader *shader,
        * and reduce later work if the same shader is linked multiple times
        */
       while (do_common_optimization(shader->ir, false, false, options,
-                                    ctx->Const.NativeIntegers))
+                                    ctx->Const.NativeIntegers!=GL_FALSE))
          ;
 
       validate_ir_tree(shader->ir);

--- a/src/glsl/linker.cpp
+++ b/src/glsl/linker.cpp
@@ -2531,7 +2531,7 @@ link_shaders(struct gl_context *ctx, struct gl_shader_program *prog)
       }
 
       prog->ARB_fragment_coord_conventions_enable |=
-         prog->Shaders[i]->ARB_fragment_coord_conventions_enable;
+         ( prog->Shaders[i]->ARB_fragment_coord_conventions_enable ? GL_TRUE : GL_FALSE );
 
       gl_shader_stage shader_type = prog->Shaders[i]->Stage;
       shader_list[shader_type][num_shaders[shader_type]] = prog->Shaders[i];
@@ -2695,7 +2695,7 @@ link_shaders(struct gl_context *ctx, struct gl_shader_program *prog)
 
       while (do_common_optimization(prog->_LinkedShaders[i]->ir, true, false,
                                     &ctx->Const.ShaderCompilerOptions[i],
-                                    ctx->Const.NativeIntegers))
+                                    ctx->Const.NativeIntegers != GL_FALSE))
 	 ;
    }
 


### PR DESCRIPTION
Visual Studio 2015 shows these warnings:

`C4800: 'GLboolean': forcing value to bool 'true' or 'false' (performance warning)`
`C4805: '|=': unsafe mix of type 'GLboolean' and type 'bool' in operation`

This pull request fixes them.
