### PR TITLE
_mesa_error_no_memory compilation fix.  _mesa_error_no_memory already…

### DIFF
--- a/src/glsl/main.cpp
+++ b/src/glsl/main.cpp
@@ -40,12 +40,6 @@
 
 static int glsl_version = 330;
 
-extern "C" void
-_mesa_error_no_memory(const char *caller)
-{
-   fprintf(stderr, "Mesa error: out of memory in %s", caller);
-}
-
 static void
 initialize_context(struct gl_context *ctx, gl_api api)
 {


### PR DESCRIPTION
… defined in src/glsl/standalone_scaffolding.cpp

Linux builds were erroring out.  _mesa_error_no_memory was defined twice.  Not sure how this compiles currently with both implementations of _mesa_error_no_memory method.  

looks to be related to issue #92 