### PR TITLE
Linux fixes

### DIFF
--- a/src/glsl/glsl_optimizer.cpp
+++ b/src/glsl/glsl_optimizer.cpp
@@ -440,8 +440,12 @@ static bool propagate_precision(exec_list* list, bool assign_high_to_undefined)
 static void do_optimization_passes(exec_list* ir, bool linked, _mesa_glsl_parse_state* state, void* mem_ctx)
 {
 	bool progress;
+	// FIXME: Shouldn't need to bound the number of passes
+	int passes = 0,
+		kMaximumPasses = 1000;
 	do {
 		progress = false;
+		++passes;
 		bool progress2;
 		debug_print_ir ("Initial", ir, state, mem_ctx);
 		if (linked) {
@@ -497,7 +501,7 @@ static void do_optimization_passes(exec_list* ir, bool linked, _mesa_glsl_parse_
 			}
 			delete ls;
 		}
-	} while (progress);
+	} while (progress && passes < kMaximumPasses);
 
 	if (!state->metal_target)
 	{

--- a/src/glsl/list.h
+++ b/src/glsl/list.h
@@ -163,8 +163,10 @@ exec_node_get_prev(struct exec_node *n)
 static inline void
 exec_node_remove(struct exec_node *n)
 {
-   n->next->prev = n->prev;
-   n->prev->next = n->next;
+   if (n->next)
+      n->next->prev = n->prev;
+   if (n->prev)
+      n->prev->next = n->next;
    n->next = NULL;
    n->prev = NULL;
 }

--- a/src/mesa/program/prog_hash_table.c
+++ b/src/mesa/program/prog_hash_table.c
@@ -84,6 +84,8 @@ hash_table_ctor(unsigned num_buckets, hash_func_t hash,
 void
 hash_table_dtor(struct hash_table *ht)
 {
+   if (!ht)
+      return;
    hash_table_clear(ht);
    free(ht);
 }

--- a/tests/glsl_optimizer_tests.cpp
+++ b/tests/glsl_optimizer_tests.cpp
@@ -315,9 +315,9 @@ static bool CheckGLSL (bool vertex, bool gles, const std::string& testName, cons
 
 static bool CheckMetal (bool vertex, bool gles, const std::string& testName, const char* prefix, const std::string& source)
 {
-#if !GOT_GFX
+#if !GOT_GFX || !defined(__APPLE__)
 	return true; // just assume it's ok
-#endif
+#else
 	
 	FILE* f = fopen ("metalTemp.metal", "wb");
 	fwrite (source.c_str(), source.size(), 1, f);
@@ -330,6 +330,7 @@ static bool CheckMetal (bool vertex, bool gles, const std::string& testName, con
 		return false;
 	}
 	return true;
+#endif
 }
 
 


### PR DESCRIPTION
Before these changes, gles2 vertex tests on Linux spend forever in do_optimization_passes
Disregarding that, `./glsl_test tests` has 62 failures before and after these changes.
(I also had to remove _mesa_error_no_memory from `src/glsl/main.cpp` to compile on Linux, but I wasn't sure if that change was appropriate to commit.)