### PR TITLE
Propagate precision qualifiers for constant declarations

### DIFF
--- a/src/glsl/ast_to_hir.cpp
+++ b/src/glsl/ast_to_hir.cpp
@@ -3042,6 +3042,12 @@ process_initializer(ir_variable *var, ast_declaration *decl,
    ir_dereference *const lhs = new(state) ir_dereference_variable(var);
    ir_rvalue *rhs = decl->initializer->hir(initializer_instructions, state);
 
+   /* Propagate precision qualifier for constant value */
+   if (type->qualifier.flags.q.constant) {
+      ir_constant *constant_value = rhs->constant_expression_value();
+      constant_value->set_precision((glsl_precision)type->qualifier.precision);
+   }
+	
    /* Calculate the constant value if this is a const or uniform
     * declaration.
     */

--- a/src/glsl/ir.cpp
+++ b/src/glsl/ir.cpp
@@ -647,8 +647,8 @@ ir_constant::ir_constant()
 }
 
 ir_constant::ir_constant(const struct glsl_type *type,
-			 const ir_constant_data *data)
-   : ir_rvalue(ir_type_constant, glsl_precision_undefined)
+			 const ir_constant_data *data, glsl_precision precision)
+   : ir_rvalue(ir_type_constant, precision)
 {
    assert((type->base_type >= GLSL_TYPE_UINT)
 	  && (type->base_type <= GLSL_TYPE_BOOL));

--- a/src/glsl/ir.h
+++ b/src/glsl/ir.h
@@ -2160,7 +2160,7 @@ union ir_constant_data {
 
 class ir_constant : public ir_rvalue {
 public:
-   ir_constant(const struct glsl_type *type, const ir_constant_data *data);
+   ir_constant(const struct glsl_type *type, const ir_constant_data *data, glsl_precision precision = glsl_precision_undefined);
    ir_constant(bool b, unsigned vector_elements=1);
    ir_constant(unsigned int u, unsigned vector_elements=1);
    ir_constant(int i, unsigned vector_elements=1);

--- a/src/glsl/ir_clone.cpp
+++ b/src/glsl/ir_clone.cpp
@@ -330,7 +330,7 @@ ir_constant::clone(void *mem_ctx, struct hash_table *ht) const
    case GLSL_TYPE_INT:
    case GLSL_TYPE_FLOAT:
    case GLSL_TYPE_BOOL:
-      return new(mem_ctx) ir_constant(this->type, &this->value);
+      return new(mem_ctx) ir_constant(this->type, &this->value, this->precision);
 
    case GLSL_TYPE_STRUCT: {
       ir_constant *c = new(mem_ctx) ir_constant;
@@ -351,6 +351,7 @@ ir_constant::clone(void *mem_ctx, struct hash_table *ht) const
       ir_constant *c = new(mem_ctx) ir_constant;
 
       c->type = this->type;
+      c->set_precision(this->get_precision());
       c->array_elements = ralloc_array(c, ir_constant *, this->type->length);
       for (unsigned i = 0; i < this->type->length; i++) {
 	 c->array_elements[i] = this->array_elements[i]->clone(mem_ctx, NULL);

--- a/tests/fragment/const-precision-inES3.txt
+++ b/tests/fragment/const-precision-inES3.txt
@@ -1,0 +1,40 @@
+#version 300 es
+#define gl_FragData _glesFragData
+layout(location = 0) out mediump vec4 _glesFragData[1];
+
+struct v2f {
+    highp vec4 pos;
+    mediump vec2 uv;
+};
+
+struct u2v {
+    highp vec4 vertex;
+    mediump vec2 texcoord;
+};
+
+const mediump vec3[3] ha = vec3[3]( vec3( 1.0, 2.0, 3.0), vec3( 4.0, 5.0, 6.0), vec3( 7.0, 8.0, 9.0));
+const highp vec3[3] fa = vec3[3]( vec3( 11.0, 12.0, 13.0), vec3( 14.0, 15.0, 16.0), vec3( 17.0, 18.0, 19.0));
+
+mediump vec4 frag( in v2f i ) {
+    mediump vec3 h = vec3( 0.0);
+    highp vec3 f = vec3( 0.0);
+    highp vec3 p = vec3( i.uv.xy, 1.0);
+    highp int j = 0;
+    for ( ; (j < int((i.uv.x * 3.0))); (j++)) {
+        h += ha[j];
+        f += fa[j];
+        f += (p * ha[0]);
+    }
+    return vec4( h.xy, f.xy);
+}
+
+in mediump vec2 xlv_TEXCOORD0;
+void main() {
+    mediump vec4 xl_retval;
+    v2f xlt_i;
+    xlt_i.pos = vec4(0.0);
+    xlt_i.uv = vec2(xlv_TEXCOORD0);
+    xl_retval = frag( xlt_i);
+    gl_FragData[0] = vec4(xl_retval);
+}
+

--- a/tests/fragment/const-precision-outES3.txt
+++ b/tests/fragment/const-precision-outES3.txt
@@ -1,0 +1,33 @@
+#version 300 es
+layout(location=0) out mediump vec4 _glesFragData[1];
+in mediump vec2 xlv_TEXCOORD0;
+void main ()
+{
+  mediump vec4 tmpvar_1;
+  mediump vec2 tmpvar_2;
+  tmpvar_2 = xlv_TEXCOORD0;
+  highp vec3 p_4;
+  highp vec3 f_5;
+  mediump vec3 h_6;
+  h_6 = vec3(0.0, 0.0, 0.0);
+  f_5 = vec3(0.0, 0.0, 0.0);
+  mediump vec3 tmpvar_7;
+  tmpvar_7.z = 1.0;
+  tmpvar_7.xy = xlv_TEXCOORD0;
+  p_4 = tmpvar_7;
+  for (highp int j_3 = 0; j_3 < int((tmpvar_2.x * 3.0)); j_3++) {
+    h_6 = (h_6 + vec3[3](vec3(1.0, 2.0, 3.0), vec3(4.0, 5.0, 6.0), vec3(7.0, 8.0, 9.0))[j_3]);
+    f_5 = (f_5 + vec3[3](vec3(11.0, 12.0, 13.0), vec3(14.0, 15.0, 16.0), vec3(17.0, 18.0, 19.0))[j_3]);
+    f_5 = (f_5 + (p_4 * vec3(1.0, 2.0, 3.0)));
+  };
+  highp vec4 tmpvar_8;
+  tmpvar_8.xy = h_6.xy;
+  tmpvar_8.zw = f_5.xy;
+  tmpvar_1 = tmpvar_8;
+  _glesFragData[0] = tmpvar_1;
+}
+
+
+// stats: 12 alu 0 tex 2 flow
+// inputs: 1
+//  #0: xlv_TEXCOORD0 (medium float) 2x1 [-1]

--- a/tests/fragment/const-precision-outES3Metal.txt
+++ b/tests/fragment/const-precision-outES3Metal.txt
@@ -1,0 +1,45 @@
+#include <metal_stdlib>
+#pragma clang diagnostic ignored "-Wparentheses-equality"
+using namespace metal;
+constant half3 _xlat_mtl_const1[3] = {float3(1.0, 2.0, 3.0), float3(4.0, 5.0, 6.0), float3(7.0, 8.0, 9.0)};
+constant float3 _xlat_mtl_const2[3] = {float3(11.0, 12.0, 13.0), float3(14.0, 15.0, 16.0), float3(17.0, 18.0, 19.0)};
+struct xlatMtlShaderInput {
+  half2 xlv_TEXCOORD0;
+};
+struct xlatMtlShaderOutput {
+  half4 _glesFragData_0 [[color(0)]];
+};
+struct xlatMtlShaderUniform {
+};
+fragment xlatMtlShaderOutput xlatMtlMain (xlatMtlShaderInput _mtl_i [[stage_in]], constant xlatMtlShaderUniform& _mtl_u [[buffer(0)]])
+{
+  xlatMtlShaderOutput _mtl_o;
+  half4 tmpvar_1;
+  half2 tmpvar_2;
+  tmpvar_2 = _mtl_i.xlv_TEXCOORD0;
+  float3 p_4;
+  float3 f_5;
+  half3 h_6;
+  h_6 = half3(float3(0.0, 0.0, 0.0));
+  f_5 = float3(0.0, 0.0, 0.0);
+  half3 tmpvar_7;
+  tmpvar_7.z = half(1.0);
+  tmpvar_7.xy = _mtl_i.xlv_TEXCOORD0;
+  p_4 = float3(tmpvar_7);
+  for (int j_3 = 0; j_3 < short((tmpvar_2.x * (half)3.0)); j_3++) {
+    h_6 = (h_6 + _xlat_mtl_const1[j_3]);
+    f_5 = (f_5 + _xlat_mtl_const2[j_3]);
+    f_5 = (f_5 + (p_4 * float3(1.0, 2.0, 3.0)));
+  };
+  float4 tmpvar_8;
+  tmpvar_8.xy = float2(h_6.xy);
+  tmpvar_8.zw = f_5.xy;
+  tmpvar_1 = half4(tmpvar_8);
+  _mtl_o._glesFragData_0 = tmpvar_1;
+  return _mtl_o;
+}
+
+
+// stats: 12 alu 0 tex 2 flow
+// inputs: 1
+//  #0: xlv_TEXCOORD0 (medium float) 2x1 [-1]


### PR DESCRIPTION
Make Metal shaders use half/float types depending on precision