### PR TITLE
Fix compiling glsl_optimizer_tests.cpp on mac

### DIFF
--- a/tests/glsl_optimizer_tests.cpp
+++ b/tests/glsl_optimizer_tests.cpp
@@ -48,6 +48,7 @@ static PFNGLGETSHADERIVPROC glGetShaderiv;
 #include <OpenGL/gl.h>
 #include <OpenGL/CGLTypes.h>
 #include <dirent.h>
+#include <stdlib.h>
 static CGLContextObj s_GLContext;
 static CGLContextObj s_GLContext3;
 static bool s_GL3Active = false;


### PR DESCRIPTION
glsl_optimizer_tests.cpp needed to include stdlib to use the system function, which is used for testing metal.

This and #111 were the only changes needed to get the CMake project compiling for me.