### PR TITLE
Fix an issue with shadows on Metal when comparison value is outside [0,1] range

### DIFF
--- a/src/glsl/ir_print_metal_visitor.cpp
+++ b/src/glsl/ir_print_metal_visitor.cpp
@@ -1266,7 +1266,7 @@ void ir_print_metal_visitor::visit(ir_texture *ir)
 		// For shadow sampling, Metal right now needs a hardcoded sampler state :|
 		if (!ctx.shadowSamplerDone)
 		{
-			ctx.prefixStr.asprintf_append("constexpr sampler _mtl_xl_shadow_sampler(address::clamp_to_edge, filter::linear, compare_func::less);\n");
+			ctx.prefixStr.asprintf_append("constexpr sampler _mtl_xl_shadow_sampler(address::clamp_to_edge, filter::linear, compare_func::less_equal);\n");
 			ctx.shadowSamplerDone = true;
 		}
 		buffer.asprintf_append (".sample_compare(_mtl_xl_shadow_sampler");

--- a/src/glsl/ir_print_metal_visitor.cpp
+++ b/src/glsl/ir_print_metal_visitor.cpp
@@ -1219,14 +1219,17 @@ static void print_texture_uv (ir_print_metal_visitor* vis, ir_texture* ir, bool 
 	}
 	else if (is_shadow)
 	{
+		// Note that on metal sample_compare works differently than shadow2DEXT on GLES:
+		// it does not clamp neither the pixel value nor compare value to the [0.0, 1.0] range. To
+		// preserve same behavior we're clamping the argument explicitly.
 		if (!is_proj)
 		{
 			// regular shadow
 			vis->buffer.asprintf_append (uv_dim == 4 ? "(float3)(" : "(float2)(");
 			ir->coordinate->accept(vis);
-			vis->buffer.asprintf_append (uv_dim == 4 ? ").xyz, (" : ").xy, (float)(");
+			vis->buffer.asprintf_append (uv_dim == 4 ? ").xyz, (" : ").xy, saturate((float)(");
 			ir->coordinate->accept(vis);
-			vis->buffer.asprintf_append (uv_dim == 4 ? ").w" : ").z");
+			vis->buffer.asprintf_append (uv_dim == 4 ? ").w" : ").z)");
 		}
 		else
 		{
@@ -1235,11 +1238,11 @@ static void print_texture_uv (ir_print_metal_visitor* vis, ir_texture* ir, bool 
 			ir->coordinate->accept(vis);
 			vis->buffer.asprintf_append (").xy / (float)(");
 			ir->coordinate->accept(vis);
-			vis->buffer.asprintf_append (").w, (float)(");
+			vis->buffer.asprintf_append (").w, saturate((float)(");
 			ir->coordinate->accept(vis);
 			vis->buffer.asprintf_append (").z / (float)(");
 			ir->coordinate->accept(vis);
-			vis->buffer.asprintf_append (").w");
+			vis->buffer.asprintf_append (").w)");
 		}
 	}
 }

--- a/tests/fragment/global-struct-constant-init-metal-outES3Metal.txt
+++ b/tests/fragment/global-struct-constant-init-metal-outES3Metal.txt
@@ -1,7 +1,7 @@
 #include <metal_stdlib>
 #pragma clang diagnostic ignored "-Wparentheses-equality"
 using namespace metal;
-constexpr sampler _mtl_xl_shadow_sampler(address::clamp_to_edge, filter::linear, compare_func::less);
+constexpr sampler _mtl_xl_shadow_sampler(address::clamp_to_edge, filter::linear, compare_func::less_equal);
 struct FragmentCommonData {
   half3 diffColor;
   half3 specColor;

--- a/tests/fragment/tex2dshadow-outES3Metal.txt
+++ b/tests/fragment/tex2dshadow-outES3Metal.txt
@@ -18,9 +18,9 @@ fragment xlatMtlShaderOutput xlatMtlMain (xlatMtlShaderInput _mtl_i [[stage_in]]
   xlatMtlShaderOutput _mtl_o;
   half4 r_1 = 0;
   half4 tmpvar_2 = 0;
-  tmpvar_2 = half4((shadowmap.sample_compare(_mtl_xl_shadow_sampler, (float2)(_mtl_i.uvHi.xyz).xy, (float)(_mtl_i.uvHi.xyz).z) + shadowmap.sample_compare(_mtl_xl_shadow_sampler, (float2)(_mtl_i.uvHi).xy / (float)(_mtl_i.uvHi).w, (float)(_mtl_i.uvHi).z / (float)(_mtl_i.uvHi).w)));
+  tmpvar_2 = half4((shadowmap.sample_compare(_mtl_xl_shadow_sampler, (float2)(_mtl_i.uvHi.xyz).xy, saturate((float)(_mtl_i.uvHi.xyz).z)) + shadowmap.sample_compare(_mtl_xl_shadow_sampler, (float2)(_mtl_i.uvHi).xy / (float)(_mtl_i.uvHi).w, saturate((float)(_mtl_i.uvHi).z / (float)(_mtl_i.uvHi).w))));
   r_1.yzw = tmpvar_2.yzw;
-  r_1.x = (tmpvar_2.x + shadowmap.sample_compare(_mtl_xl_shadow_sampler, (float2)(_mtl_i.uvMed.xyz).xy, (float)(_mtl_i.uvMed.xyz).z));
+  r_1.x = (tmpvar_2.x + shadowmap.sample_compare(_mtl_xl_shadow_sampler, (float2)(_mtl_i.uvMed.xyz).xy, saturate((float)(_mtl_i.uvMed.xyz).z)));
   _mtl_o._fragColor = r_1;
   return _mtl_o;
 }

--- a/tests/fragment/tex2dshadow-outES3Metal.txt
+++ b/tests/fragment/tex2dshadow-outES3Metal.txt
@@ -1,7 +1,7 @@
 #include <metal_stdlib>
 #pragma clang diagnostic ignored "-Wparentheses-equality"
 using namespace metal;
-constexpr sampler _mtl_xl_shadow_sampler(address::clamp_to_edge, filter::linear, compare_func::less);
+constexpr sampler _mtl_xl_shadow_sampler(address::clamp_to_edge, filter::linear, compare_func::less_equal);
 struct xlatMtlShaderInput {
   float4 uvHi;
   half4 uvMed;

--- a/tests/fragment/texCubeShadow-outES3Metal.txt
+++ b/tests/fragment/texCubeShadow-outES3Metal.txt
@@ -1,7 +1,7 @@
 #include <metal_stdlib>
 #pragma clang diagnostic ignored "-Wparentheses-equality"
 using namespace metal;
-constexpr sampler _mtl_xl_shadow_sampler(address::clamp_to_edge, filter::linear, compare_func::less);
+constexpr sampler _mtl_xl_shadow_sampler(address::clamp_to_edge, filter::linear, compare_func::less_equal);
 struct xlatMtlShaderInput {
   half4 uv;
 };

--- a/tests/fragment/texProj-outES3Metal.txt
+++ b/tests/fragment/texProj-outES3Metal.txt
@@ -19,8 +19,8 @@ fragment xlatMtlShaderOutput xlatMtlMain (xlatMtlShaderInput _mtl_i [[stage_in]]
   c_1 = (tex.sample(_mtlsmp_tex, ((float2)(_mtl_i.uv).xy / (float)(_mtl_i.uv).w)) + tex.sample(_mtlsmp_tex, ((float2)(_mtl_i.uv.xyz).xy / (float)(_mtl_i.uv.xyz).z)));
   c_1 = (c_1 + tex.sample(_mtlsmp_tex, ((float2)(_mtl_i.uv).xy / (float)(_mtl_i.uv).w), level(1.0)));
   c_1 = (c_1 + tex.sample(_mtlsmp_tex, ((float2)(_mtl_i.uv.xyz).xy / (float)(_mtl_i.uv.xyz).z), level(1.0)));
-  c_1 = (c_1 + half4(shadowmap.sample_compare(_mtl_xl_shadow_sampler, (float2)(_mtl_i.uv.xyz).xy, (float)(_mtl_i.uv.xyz).z)));
-  c_1 = (c_1 + half4(shadowmap.sample_compare(_mtl_xl_shadow_sampler, (float2)(_mtl_i.uv).xy / (float)(_mtl_i.uv).w, (float)(_mtl_i.uv).z / (float)(_mtl_i.uv).w)));
+  c_1 = (c_1 + half4(shadowmap.sample_compare(_mtl_xl_shadow_sampler, (float2)(_mtl_i.uv.xyz).xy, saturate((float)(_mtl_i.uv.xyz).z))));
+  c_1 = (c_1 + half4(shadowmap.sample_compare(_mtl_xl_shadow_sampler, (float2)(_mtl_i.uv).xy / (float)(_mtl_i.uv).w, saturate((float)(_mtl_i.uv).z / (float)(_mtl_i.uv).w))));
   _mtl_o._fragData = c_1;
   return _mtl_o;
 }

--- a/tests/fragment/texProj-outES3Metal.txt
+++ b/tests/fragment/texProj-outES3Metal.txt
@@ -1,7 +1,7 @@
 #include <metal_stdlib>
 #pragma clang diagnostic ignored "-Wparentheses-equality"
 using namespace metal;
-constexpr sampler _mtl_xl_shadow_sampler(address::clamp_to_edge, filter::linear, compare_func::less);
+constexpr sampler _mtl_xl_shadow_sampler(address::clamp_to_edge, filter::linear, compare_func::less_equal);
 struct xlatMtlShaderInput {
   float4 uv;
 };


### PR DESCRIPTION
On Metal, when objects are outside the far plane, we display shadows for them incorrectly, because we don't clamp the comparison value correctly and then incorrectly compare it to the shadowmap. This PR fixes the issue by correctly clamping the comparison value and fixing the comparison parameter to correctly interpret the newly clamped values.