### PR TITLE
Added `extern "C"` block to glsl_optimizer.h

### DIFF
--- a/src/glsl/glsl_optimizer.h
+++ b/src/glsl/glsl_optimizer.h
@@ -1,6 +1,9 @@
 #pragma once
 #ifndef GLSL_OPTIMIZER_H
 #define GLSL_OPTIMIZER_H
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /*
  Main GLSL optimizer interface.
@@ -88,4 +91,7 @@ void glslopt_shader_get_texture_desc (glslopt_shader* shader, int index, const c
 void glslopt_shader_get_stats (glslopt_shader* shader, int* approxMath, int* approxTex, int* approxFlow);
 
 
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 #endif /* GLSL_OPTIMIZER_H */


### PR DESCRIPTION
This makes it easier to use the library in C or another programming language like Rust which can interface with the C ABI.