### PR TITLE
Fix texelFetch & sampler2DMS support

### DIFF
--- a/src/glsl/glsl_optimizer.cpp
+++ b/src/glsl/glsl_optimizer.cpp
@@ -48,7 +48,7 @@ initialize_mesa_context(struct gl_context *ctx, glslopt_target api)
 	{
 	default:
 	case kGlslTargetOpenGL:
-		ctx->Const.GLSLVersion = 140;
+		ctx->Const.GLSLVersion = 150;
 		break;
 	case kGlslTargetOpenGLES20:
 		ctx->Extensions.OES_standard_derivatives = true;

--- a/src/glsl/ir_print_glsl_visitor.cpp
+++ b/src/glsl/ir_print_glsl_visitor.cpp
@@ -830,7 +830,7 @@ void ir_print_glsl_visitor::visit(ir_texture *ir)
 		sampler_uv_dim += 1;
 	if (is_array)
 		sampler_uv_dim += 1;
-	const bool is_proj = (ir->op == ir_tex && uv_dim > sampler_uv_dim);
+	const bool is_proj = ((ir->op == ir_tex || ir->op == ir_txb || ir->op == ir_txl || ir->op == ir_txd) && uv_dim > sampler_uv_dim);
 	const bool is_lod = (ir->op == ir_txl);
 	
 	if (is_lod && state->es_shader && state->language_version < 300 && state->stage == MESA_SHADER_FRAGMENT)

--- a/src/glsl/ir_print_glsl_visitor.cpp
+++ b/src/glsl/ir_print_glsl_visitor.cpp
@@ -830,7 +830,7 @@ void ir_print_glsl_visitor::visit(ir_texture *ir)
 		sampler_uv_dim += 1;
 	if (is_array)
 		sampler_uv_dim += 1;
-	const bool is_proj = (uv_dim > sampler_uv_dim);
+	const bool is_proj = (ir->op == ir_tex && uv_dim > sampler_uv_dim);
 	const bool is_lod = (ir->op == ir_txl);
 	
 	if (is_lod && state->es_shader && state->language_version < 300 && state->stage == MESA_SHADER_FRAGMENT)
@@ -872,7 +872,7 @@ void ir_print_glsl_visitor::visit(ir_texture *ir)
     }
     else 
     {
-        if (ir->op == ir_txf)
+        if (ir->op == ir_txf || ir->op == ir_txf_ms)
             buffer.asprintf_append ("texelFetch");
         else
             buffer.asprintf_append ("texture");
@@ -923,6 +923,13 @@ void ir_print_glsl_visitor::visit(ir_texture *ir)
 		ir->lod_info.lod->accept(this);
 	}
 	
+	// sample index
+	if (ir->op == ir_txf_ms)
+	{
+		buffer.asprintf_append (", ");
+		ir->lod_info.sample_index->accept(this);
+	}
+
 	// grad
 	if (ir->op == ir_txd)
 	{

--- a/tests/fragment/array-const-outES3Metal.txt
+++ b/tests/fragment/array-const-outES3Metal.txt
@@ -1,4 +1,5 @@
 #include <metal_stdlib>
+#pragma clang diagnostic ignored "-Wparentheses-equality"
 using namespace metal;
 struct xlatMtlShaderInput {
 };

--- a/tests/fragment/array-constconst-outES3Metal.txt
+++ b/tests/fragment/array-constconst-outES3Metal.txt
@@ -1,4 +1,5 @@
 #include <metal_stdlib>
+#pragma clang diagnostic ignored "-Wparentheses-equality"
 using namespace metal;
 struct xlatMtlShaderInput {
 };

--- a/tests/fragment/ast-outES3Metal.txt
+++ b/tests/fragment/ast-outES3Metal.txt
@@ -1,4 +1,5 @@
 #include <metal_stdlib>
+#pragma clang diagnostic ignored "-Wparentheses-equality"
 using namespace metal;
 struct xlatMtlShaderInput {
   float4 gl_FragCoord [[position]];

--- a/tests/fragment/bug-loop-undeclaredinductor-outES3Metal.txt
+++ b/tests/fragment/bug-loop-undeclaredinductor-outES3Metal.txt
@@ -1,4 +1,5 @@
 #include <metal_stdlib>
+#pragma clang diagnostic ignored "-Wparentheses-equality"
 using namespace metal;
 struct xlatMtlShaderInput {
   half2 xlv_TEXCOORD0;

--- a/tests/fragment/bug-sampler-highp-outES3Metal.txt
+++ b/tests/fragment/bug-sampler-highp-outES3Metal.txt
@@ -1,4 +1,5 @@
 #include <metal_stdlib>
+#pragma clang diagnostic ignored "-Wparentheses-equality"
 using namespace metal;
 struct xlatMtlShaderInput {
   float2 varUV;

--- a/tests/fragment/bug-sampler-highpfull-outES3Metal.txt
+++ b/tests/fragment/bug-sampler-highpfull-outES3Metal.txt
@@ -1,4 +1,5 @@
 #include <metal_stdlib>
+#pragma clang diagnostic ignored "-Wparentheses-equality"
 using namespace metal;
 constant float2 _xlat_mtl_const1[12] = {float2(-0.326212, -0.40581), float2(-0.840144, -0.07358), float2(-0.695914, 0.457137), float2(-0.203345, 0.620716), float2(0.96234, -0.194983), float2(0.473434, -0.480026), float2(0.519456, 0.767022), float2(0.185461, -0.893124), float2(0.507431, 0.064425), float2(0.89642, 0.412458), float2(-0.32194, -0.932615), float2(-0.791559, -0.59771)};
 struct xlatMtlShaderInput {

--- a/tests/fragment/builtin-vars-outES3Metal.txt
+++ b/tests/fragment/builtin-vars-outES3Metal.txt
@@ -1,4 +1,5 @@
 #include <metal_stdlib>
+#pragma clang diagnostic ignored "-Wparentheses-equality"
 using namespace metal;
 struct xlatMtlShaderInput {
   float2 gl_PointCoord [[point_coord]];

--- a/tests/fragment/fragdepth-outES3Metal.txt
+++ b/tests/fragment/fragdepth-outES3Metal.txt
@@ -1,4 +1,5 @@
 #include <metal_stdlib>
+#pragma clang diagnostic ignored "-Wparentheses-equality"
 using namespace metal;
 struct xlatMtlShaderInput {
 };

--- a/tests/fragment/framebuffer_fetch-outES3Metal.txt
+++ b/tests/fragment/framebuffer_fetch-outES3Metal.txt
@@ -1,4 +1,5 @@
 #include <metal_stdlib>
+#pragma clang diagnostic ignored "-Wparentheses-equality"
 using namespace metal;
 struct xlatMtlShaderInput {
   half4 xlv_TEXCOORD0;

--- a/tests/fragment/glsl120-basic-outES3Metal.txt
+++ b/tests/fragment/glsl120-basic-outES3Metal.txt
@@ -1,4 +1,5 @@
 #include <metal_stdlib>
+#pragma clang diagnostic ignored "-Wparentheses-equality"
 using namespace metal;
 struct xlatMtlShaderInput {
 };

--- a/tests/fragment/intrinsics-outES3Metal.txt
+++ b/tests/fragment/intrinsics-outES3Metal.txt
@@ -1,4 +1,5 @@
 #include <metal_stdlib>
+#pragma clang diagnostic ignored "-Wparentheses-equality"
 using namespace metal;
 struct xlatMtlShaderInput {
   float4 xlv_TEXCOORD0;

--- a/tests/fragment/loop-for-outES3Metal.txt
+++ b/tests/fragment/loop-for-outES3Metal.txt
@@ -1,4 +1,5 @@
 #include <metal_stdlib>
+#pragma clang diagnostic ignored "-Wparentheses-equality"
 using namespace metal;
 struct xlatMtlShaderInput {
   float2 xlv_uv;

--- a/tests/fragment/loop-forafterdiscard-outES3Metal.txt
+++ b/tests/fragment/loop-forafterdiscard-outES3Metal.txt
@@ -1,4 +1,5 @@
 #include <metal_stdlib>
+#pragma clang diagnostic ignored "-Wparentheses-equality"
 using namespace metal;
 struct xlatMtlShaderInput {
   float2 xlv_uv;

--- a/tests/fragment/matrix-cast-types-outES3Metal.txt
+++ b/tests/fragment/matrix-cast-types-outES3Metal.txt
@@ -1,4 +1,5 @@
 #include <metal_stdlib>
+#pragma clang diagnostic ignored "-Wparentheses-equality"
 using namespace metal;
 inline float4x4 _xlcast_float4x4(half4x4 v) { return float4x4(float4(v[0]), float4(v[1]), float4(v[2]), float4(v[3])); }
 inline float3x3 _xlcast_float3x3(half3x3 v) { return float3x3(float3(v[0]), float3(v[1]), float3(v[2])); }

--- a/tests/fragment/matrix-ops-outES3Metal.txt
+++ b/tests/fragment/matrix-ops-outES3Metal.txt
@@ -1,4 +1,5 @@
 #include <metal_stdlib>
+#pragma clang diagnostic ignored "-Wparentheses-equality"
 using namespace metal;
 inline float4x4 _xlinit_float4x4(float v) { return float4x4(float4(v), float4(v), float4(v), float4(v)); }
 inline float3x3 _xlinit_float3x3(float v) { return float3x3(float3(v), float3(v), float3(v)); }

--- a/tests/fragment/mrt-mixed-array-outES3Metal.txt
+++ b/tests/fragment/mrt-mixed-array-outES3Metal.txt
@@ -1,4 +1,5 @@
 #include <metal_stdlib>
+#pragma clang diagnostic ignored "-Wparentheses-equality"
 using namespace metal;
 struct xlatMtlShaderInput {
 };

--- a/tests/fragment/mrt-outES3Metal.txt
+++ b/tests/fragment/mrt-outES3Metal.txt
@@ -1,4 +1,5 @@
 #include <metal_stdlib>
+#pragma clang diagnostic ignored "-Wparentheses-equality"
 using namespace metal;
 struct xlatMtlShaderInput {
 };

--- a/tests/fragment/mrt-unused-outES3Metal.txt
+++ b/tests/fragment/mrt-unused-outES3Metal.txt
@@ -1,4 +1,5 @@
 #include <metal_stdlib>
+#pragma clang diagnostic ignored "-Wparentheses-equality"
 using namespace metal;
 struct xlatMtlShaderInput {
   half4 xlv_COLOR0;

--- a/tests/fragment/opt-dead-texloadstreeshadow-outES3Metal.txt
+++ b/tests/fragment/opt-dead-texloadstreeshadow-outES3Metal.txt
@@ -1,4 +1,5 @@
 #include <metal_stdlib>
+#pragma clang diagnostic ignored "-Wparentheses-equality"
 using namespace metal;
 struct xlatMtlShaderInput {
 };

--- a/tests/fragment/opt-grafting-precision-outES3Metal.txt
+++ b/tests/fragment/opt-grafting-precision-outES3Metal.txt
@@ -1,4 +1,5 @@
 #include <metal_stdlib>
+#pragma clang diagnostic ignored "-Wparentheses-equality"
 using namespace metal;
 struct xlatMtlShaderInput {
   half3 normal;

--- a/tests/fragment/prec-expressions-outES3Metal.txt
+++ b/tests/fragment/prec-expressions-outES3Metal.txt
@@ -1,4 +1,5 @@
 #include <metal_stdlib>
+#pragma clang diagnostic ignored "-Wparentheses-equality"
 using namespace metal;
 struct xlatMtlShaderInput {
 };

--- a/tests/fragment/prec-matrix-constr-outES3Metal.txt
+++ b/tests/fragment/prec-matrix-constr-outES3Metal.txt
@@ -1,4 +1,5 @@
 #include <metal_stdlib>
+#pragma clang diagnostic ignored "-Wparentheses-equality"
 using namespace metal;
 struct xlatMtlShaderInput {
   half3 inNormal;

--- a/tests/fragment/qualifiers-layout-outES3Metal.txt
+++ b/tests/fragment/qualifiers-layout-outES3Metal.txt
@@ -1,4 +1,5 @@
 #include <metal_stdlib>
+#pragma clang diagnostic ignored "-Wparentheses-equality"
 using namespace metal;
 struct xlatMtlShaderInput {
 };

--- a/tests/fragment/sampler-precision-outES3Metal.txt
+++ b/tests/fragment/sampler-precision-outES3Metal.txt
@@ -1,4 +1,5 @@
 #include <metal_stdlib>
+#pragma clang diagnostic ignored "-Wparentheses-equality"
 using namespace metal;
 struct xlatMtlShaderInput {
   float4 varUV;

--- a/tests/fragment/ternary-outES3Metal.txt
+++ b/tests/fragment/ternary-outES3Metal.txt
@@ -1,4 +1,5 @@
 #include <metal_stdlib>
+#pragma clang diagnostic ignored "-Wparentheses-equality"
 using namespace metal;
 struct xlatMtlShaderInput {
   float4 xlv_TEXCOORD0;

--- a/tests/fragment/ternary-vec4-outES3Metal.txt
+++ b/tests/fragment/ternary-vec4-outES3Metal.txt
@@ -1,4 +1,5 @@
 #include <metal_stdlib>
+#pragma clang diagnostic ignored "-Wparentheses-equality"
 using namespace metal;
 struct xlatMtlShaderInput {
   float4 xlv_TEXCOORD0;

--- a/tests/fragment/tex2DArray-outES3Metal.txt
+++ b/tests/fragment/tex2DArray-outES3Metal.txt
@@ -1,4 +1,5 @@
 #include <metal_stdlib>
+#pragma clang diagnostic ignored "-Wparentheses-equality"
 using namespace metal;
 struct xlatMtlShaderInput {
   float4 uv;

--- a/tests/fragment/tex2dgrad-outES3Metal.txt
+++ b/tests/fragment/tex2dgrad-outES3Metal.txt
@@ -1,4 +1,5 @@
 #include <metal_stdlib>
+#pragma clang diagnostic ignored "-Wparentheses-equality"
 using namespace metal;
 struct xlatMtlShaderInput {
   half3 uv1;

--- a/tests/fragment/tex2dlod-outES3Metal.txt
+++ b/tests/fragment/tex2dlod-outES3Metal.txt
@@ -1,4 +1,5 @@
 #include <metal_stdlib>
+#pragma clang diagnostic ignored "-Wparentheses-equality"
 using namespace metal;
 struct xlatMtlShaderInput {
   float4 uvHi;

--- a/tests/fragment/tex2dshadow-outES3Metal.txt
+++ b/tests/fragment/tex2dshadow-outES3Metal.txt
@@ -1,4 +1,5 @@
 #include <metal_stdlib>
+#pragma clang diagnostic ignored "-Wparentheses-equality"
 using namespace metal;
 constexpr sampler _mtl_xl_shadow_sampler(address::clamp_to_edge, filter::linear, compare_func::less);
 struct xlatMtlShaderInput {

--- a/tests/fragment/tex3D-outES3Metal.txt
+++ b/tests/fragment/tex3D-outES3Metal.txt
@@ -1,4 +1,5 @@
 #include <metal_stdlib>
+#pragma clang diagnostic ignored "-Wparentheses-equality"
 using namespace metal;
 struct xlatMtlShaderInput {
   float3 uv;

--- a/tests/fragment/texCubeShadow-outES3Metal.txt
+++ b/tests/fragment/texCubeShadow-outES3Metal.txt
@@ -1,4 +1,5 @@
 #include <metal_stdlib>
+#pragma clang diagnostic ignored "-Wparentheses-equality"
 using namespace metal;
 constexpr sampler _mtl_xl_shadow_sampler(address::clamp_to_edge, filter::linear, compare_func::less);
 struct xlatMtlShaderInput {

--- a/tests/fragment/texOffset-outES3Metal.txt
+++ b/tests/fragment/texOffset-outES3Metal.txt
@@ -1,4 +1,5 @@
 #include <metal_stdlib>
+#pragma clang diagnostic ignored "-Wparentheses-equality"
 using namespace metal;
 struct xlatMtlShaderInput {
   half3 uv;

--- a/tests/fragment/texProj-outES3Metal.txt
+++ b/tests/fragment/texProj-outES3Metal.txt
@@ -1,4 +1,5 @@
 #include <metal_stdlib>
+#pragma clang diagnostic ignored "-Wparentheses-equality"
 using namespace metal;
 constexpr sampler _mtl_xl_shadow_sampler(address::clamp_to_edge, filter::linear, compare_func::less);
 struct xlatMtlShaderInput {

--- a/tests/fragment/texelFetchMSAA-in.txt
+++ b/tests/fragment/texelFetchMSAA-in.txt
@@ -1,0 +1,7 @@
+#version 150
+uniform sampler2DMS tex;
+in vec2 uv;
+out vec4 color;
+void main() {
+	color = texelFetch(tex, ivec2(uv), 3);
+}

--- a/tests/fragment/texelFetchMSAA-out.txt
+++ b/tests/fragment/texelFetchMSAA-out.txt
@@ -1,0 +1,15 @@
+#version 150
+uniform sampler2DMS tex;
+in vec2 uv;
+out vec4 color;
+void main ()
+{
+  color = texelFetch (tex, ivec2(uv), 3);
+}
+
+
+// stats: 1 alu 1 tex 0 flow
+// inputs: 1
+//  #0: uv (high float) 2x1 [-1]
+// textures: 1
+//  #0: tex (high other) 0x0 [-1]

--- a/tests/fragment/z-DirLMBasis-outES3Metal.txt
+++ b/tests/fragment/z-DirLMBasis-outES3Metal.txt
@@ -1,4 +1,5 @@
 #include <metal_stdlib>
+#pragma clang diagnostic ignored "-Wparentheses-equality"
 using namespace metal;
 struct xlatMtlShaderInput {
   float2 xlv_TEXCOORD0;

--- a/tests/fragment/z-LightShaftsCoord-outES3Metal.txt
+++ b/tests/fragment/z-LightShaftsCoord-outES3Metal.txt
@@ -1,4 +1,5 @@
 #include <metal_stdlib>
+#pragma clang diagnostic ignored "-Wparentheses-equality"
 using namespace metal;
 struct xlatMtlShaderInput {
   float2 xlv_TEXCOORD0;

--- a/tests/fragment/z-alphabumpspec-outES3Metal.txt
+++ b/tests/fragment/z-alphabumpspec-outES3Metal.txt
@@ -1,4 +1,5 @@
 #include <metal_stdlib>
+#pragma clang diagnostic ignored "-Wparentheses-equality"
 using namespace metal;
 struct xlatMtlShaderInput {
   float4 _uv0;

--- a/tests/fragment/z-collectshadows-outES3Metal.txt
+++ b/tests/fragment/z-collectshadows-outES3Metal.txt
@@ -1,4 +1,5 @@
 #include <metal_stdlib>
+#pragma clang diagnostic ignored "-Wparentheses-equality"
 using namespace metal;
 struct xlatMtlShaderInput {
   float2 xlv_TEXCOORD0;

--- a/tests/fragment/z-fxaa-preset3-outES3Metal.txt
+++ b/tests/fragment/z-fxaa-preset3-outES3Metal.txt
@@ -1,4 +1,5 @@
 #include <metal_stdlib>
+#pragma clang diagnostic ignored "-Wparentheses-equality"
 using namespace metal;
 struct xlatMtlShaderInput {
   float2 xlv_TEXCOORD0;

--- a/tests/fragment/z-prepasslight-outES3Metal.txt
+++ b/tests/fragment/z-prepasslight-outES3Metal.txt
@@ -1,4 +1,5 @@
 #include <metal_stdlib>
+#pragma clang diagnostic ignored "-Wparentheses-equality"
 using namespace metal;
 struct xlatMtlShaderInput {
   float4 xlv_TEXCOORD0;

--- a/tests/fragment/z-tonemap-usercurve-outES3Metal.txt
+++ b/tests/fragment/z-tonemap-usercurve-outES3Metal.txt
@@ -1,4 +1,5 @@
 #include <metal_stdlib>
+#pragma clang diagnostic ignored "-Wparentheses-equality"
 using namespace metal;
 struct xlatMtlShaderInput {
   float2 xlv_TEXCOORD0;

--- a/tests/fragment/z-treeleafloop-outES3Metal.txt
+++ b/tests/fragment/z-treeleafloop-outES3Metal.txt
@@ -1,4 +1,5 @@
 #include <metal_stdlib>
+#pragma clang diagnostic ignored "-Wparentheses-equality"
 using namespace metal;
 struct xlatMtlShaderInput {
   float2 xlv_TEXCOORD0;

--- a/tests/fragment/z-unishader-dirlm-outES3Metal.txt
+++ b/tests/fragment/z-unishader-dirlm-outES3Metal.txt
@@ -1,4 +1,5 @@
 #include <metal_stdlib>
+#pragma clang diagnostic ignored "-Wparentheses-equality"
 using namespace metal;
 struct xlatMtlShaderInput {
   float4 xlv_TEXCOORD0;

--- a/tests/fragment/z-unity-spot-outES3Metal.txt
+++ b/tests/fragment/z-unity-spot-outES3Metal.txt
@@ -1,4 +1,5 @@
 #include <metal_stdlib>
+#pragma clang diagnostic ignored "-Wparentheses-equality"
 using namespace metal;
 struct xlatMtlShaderInput {
   float2 xlv_TEXCOORD0;

--- a/tests/fragment/zun-MobileBumpSpec-outES3Metal.txt
+++ b/tests/fragment/zun-MobileBumpSpec-outES3Metal.txt
@@ -1,4 +1,5 @@
 #include <metal_stdlib>
+#pragma clang diagnostic ignored "-Wparentheses-equality"
 using namespace metal;
 struct xlatMtlShaderInput {
   half2 xlv_TEXCOORD0;

--- a/tests/fragment/zun-SSAO24-outES3Metal.txt
+++ b/tests/fragment/zun-SSAO24-outES3Metal.txt
@@ -1,4 +1,5 @@
 #include <metal_stdlib>
+#pragma clang diagnostic ignored "-Wparentheses-equality"
 using namespace metal;
 constant float3 _xlat_mtl_const1[8] = {float3(0.0130572, 0.587232, -0.119337), float3(0.323078, 0.0220727, -0.418873), float3(-0.310725, -0.191367, 0.0561369), float3(-0.479646, 0.0939877, -0.580265), float3(0.139999, -0.33577, 0.559679), float3(-0.248458, 0.255532, 0.348944), float3(0.18719, -0.702764, -0.231748), float3(0.884915, 0.284208, 0.368524)};
 struct xlatMtlShaderInput {

--- a/tests/vertex/MF-GodRays-outES3Metal.txt
+++ b/tests/vertex/MF-GodRays-outES3Metal.txt
@@ -1,4 +1,5 @@
 #include <metal_stdlib>
+#pragma clang diagnostic ignored "-Wparentheses-equality"
 using namespace metal;
 struct xlatMtlShaderInput {
   float4 _inVertex [[attribute(0)]];

--- a/tests/vertex/bug-swizzle-lhs-cast-outES3Metal.txt
+++ b/tests/vertex/bug-swizzle-lhs-cast-outES3Metal.txt
@@ -1,4 +1,5 @@
 #include <metal_stdlib>
+#pragma clang diagnostic ignored "-Wparentheses-equality"
 using namespace metal;
 struct xlatMtlShaderInput {
   float4 _glesVertex [[attribute(0)]];

--- a/tests/vertex/builtin-vars-outES3Metal.txt
+++ b/tests/vertex/builtin-vars-outES3Metal.txt
@@ -1,4 +1,5 @@
 #include <metal_stdlib>
+#pragma clang diagnostic ignored "-Wparentheses-equality"
 using namespace metal;
 struct xlatMtlShaderInput {
   float3 _inPos [[attribute(0)]];

--- a/tests/vertex/inputs-outES3Metal.txt
+++ b/tests/vertex/inputs-outES3Metal.txt
@@ -1,4 +1,5 @@
 #include <metal_stdlib>
+#pragma clang diagnostic ignored "-Wparentheses-equality"
 using namespace metal;
 struct xlatMtlShaderInput {
   float4 _glesVertex [[attribute(0)]];

--- a/tests/vertex/loops-for-withvec4-outES3Metal.txt
+++ b/tests/vertex/loops-for-withvec4-outES3Metal.txt
@@ -1,4 +1,5 @@
 #include <metal_stdlib>
+#pragma clang diagnostic ignored "-Wparentheses-equality"
 using namespace metal;
 struct xlatMtlShaderInput {
   float4 dcl_Input0_POSITION0 [[attribute(0)]];

--- a/tests/vertex/loops-for-withvec4inductorW-outES3Metal.txt
+++ b/tests/vertex/loops-for-withvec4inductorW-outES3Metal.txt
@@ -1,4 +1,5 @@
 #include <metal_stdlib>
+#pragma clang diagnostic ignored "-Wparentheses-equality"
 using namespace metal;
 struct xlatMtlShaderInput {
   float4 in_POSITION0 [[attribute(0)]];

--- a/tests/vertex/loops-forlimitbreak-outES3Metal.txt
+++ b/tests/vertex/loops-forlimitbreak-outES3Metal.txt
@@ -1,4 +1,5 @@
 #include <metal_stdlib>
+#pragma clang diagnostic ignored "-Wparentheses-equality"
 using namespace metal;
 struct xlatMtlShaderInput {
   float4 _glesVertex [[attribute(0)]];

--- a/tests/vertex/loops-forvarious-outES3Metal.txt
+++ b/tests/vertex/loops-forvarious-outES3Metal.txt
@@ -1,4 +1,5 @@
 #include <metal_stdlib>
+#pragma clang diagnostic ignored "-Wparentheses-equality"
 using namespace metal;
 struct xlatMtlShaderInput {
   float4 _inVertex [[attribute(0)]];

--- a/tests/vertex/matrix-casts-outES3Metal.txt
+++ b/tests/vertex/matrix-casts-outES3Metal.txt
@@ -1,4 +1,5 @@
 #include <metal_stdlib>
+#pragma clang diagnostic ignored "-Wparentheses-equality"
 using namespace metal;
 inline float4x4 _xlcast_float4x4(half4x4 v) { return float4x4(float4(v[0]), float4(v[1]), float4(v[2]), float4(v[3])); }
 inline float3x3 _xlcast_float3x3(half3x3 v) { return float3x3(float3(v[0]), float3(v[1]), float3(v[2])); }

--- a/tests/vertex/opt-matrix-transpose-mul-outES3Metal.txt
+++ b/tests/vertex/opt-matrix-transpose-mul-outES3Metal.txt
@@ -1,4 +1,5 @@
 #include <metal_stdlib>
+#pragma clang diagnostic ignored "-Wparentheses-equality"
 using namespace metal;
 struct xlatMtlShaderInput {
   float4 attrVertex [[attribute(0)]];

--- a/tests/vertex/swizzle-casts-outES3Metal.txt
+++ b/tests/vertex/swizzle-casts-outES3Metal.txt
@@ -1,4 +1,5 @@
 #include <metal_stdlib>
+#pragma clang diagnostic ignored "-Wparentheses-equality"
 using namespace metal;
 struct xlatMtlShaderInput {
   float4 _glesVertex [[attribute(0)]];

--- a/tests/vertex/types-outES3Metal.txt
+++ b/tests/vertex/types-outES3Metal.txt
@@ -1,4 +1,5 @@
 #include <metal_stdlib>
+#pragma clang diagnostic ignored "-Wparentheses-equality"
 using namespace metal;
 struct xlatMtlShaderInput {
   float4 _inVertex [[attribute(0)]];

--- a/tests/vertex/uniforms-arrays-outES3Metal.txt
+++ b/tests/vertex/uniforms-arrays-outES3Metal.txt
@@ -1,4 +1,5 @@
 #include <metal_stdlib>
+#pragma clang diagnostic ignored "-Wparentheses-equality"
 using namespace metal;
 struct xlatMtlShaderInput {
   float4 _glesVertex [[attribute(0)]];

--- a/tests/vertex/z-NichsHybridLightVectorInsertBug-outES3Metal.txt
+++ b/tests/vertex/z-NichsHybridLightVectorInsertBug-outES3Metal.txt
@@ -1,4 +1,5 @@
 #include <metal_stdlib>
+#pragma clang diagnostic ignored "-Wparentheses-equality"
 using namespace metal;
 struct xlatMtlShaderInput {
   float4 _glesVertex [[attribute(0)]];

--- a/tests/vertex/z-prepasslight-outES3Metal.txt
+++ b/tests/vertex/z-prepasslight-outES3Metal.txt
@@ -1,4 +1,5 @@
 #include <metal_stdlib>
+#pragma clang diagnostic ignored "-Wparentheses-equality"
 using namespace metal;
 struct xlatMtlShaderInput {
   float4 _vertex [[attribute(0)]];

--- a/tests/vertex/z-treeleaf-outES3Metal.txt
+++ b/tests/vertex/z-treeleaf-outES3Metal.txt
@@ -1,4 +1,5 @@
 #include <metal_stdlib>
+#pragma clang diagnostic ignored "-Wparentheses-equality"
 using namespace metal;
 struct xlatMtlShaderInput {
   float4 _inVertex [[attribute(0)]];


### PR DESCRIPTION
This requires bumping the GLSLVersion constant up but AFAICS it's not used for the output - #version directive is preserved, and it's just used to populate the available definitions/features. Let me know if you want me to fix this by making another kGlslTarget enum value.

More importantly, texelFetch was converted to textureProj during ir->glsl pass :) so this fixes that.

I'm not sure how to run tests so I haven't ran tests :(
