### PR TITLE
Support for high precision Metal texture samplers.

### DIFF
--- a/src/glsl/glsl_optimizer.cpp
+++ b/src/glsl/glsl_optimizer.cpp
@@ -265,6 +265,14 @@ static void propagate_precision_expr(ir_instruction *ir, void *data)
 	
 }
 
+static void propagate_precision_texture_metal(ir_instruction* ir, void* data)
+{
+	// There are no precision specifiers in Metal
+	ir_texture* tex = ir->as_texture();
+	if (tex)
+		tex->set_precision(glsl_precision_undefined);
+}
+
 static void propagate_precision_texture(ir_instruction *ir, void *data)
 {
 	ir_texture* tex = ir->as_texture();
@@ -386,7 +394,7 @@ static void propagate_precision_call(ir_instruction *ir, void *data)
 	}
 }
 
-static bool propagate_precision(exec_list* list, bool assign_high_to_undefined)
+static bool propagate_precision(exec_list* list, bool metal_target)
 {
 	bool anyProgress = false;
 	precision_ctx ctx;
@@ -396,7 +404,11 @@ static bool propagate_precision(exec_list* list, bool assign_high_to_undefined)
 		ctx.root_ir = list;
 		foreach_in_list(ir_instruction, ir, list)
 		{
-			visit_tree (ir, propagate_precision_texture, &ctx);
+			if (metal_target)
+				visit_tree (ir, propagate_precision_texture_metal, &ctx);
+			else
+				visit_tree (ir, propagate_precision_texture, &ctx);
+				
 			visit_tree (ir, propagate_precision_deref, &ctx);
 			bool hadProgress = ctx.res;
 			ctx.res = false;
@@ -417,7 +429,7 @@ static bool propagate_precision(exec_list* list, bool assign_high_to_undefined)
 	anyProgress |= ctx.res;
 	
 	// for globals that have undefined precision, set it to highp
-	if (assign_high_to_undefined)
+	if (metal_target)
 	{
 		foreach_in_list(ir_instruction, ir, list)
 		{

--- a/src/glsl/ir_print_metal_visitor.cpp
+++ b/src/glsl/ir_print_metal_visitor.cpp
@@ -1271,6 +1271,12 @@ void ir_print_metal_visitor::visit(ir_texture *ir)
 		sampler_uv_dim += 1;
 	const bool is_proj = (uv_dim > sampler_uv_dim) && !is_array;
 	
+    // Construct as the expected return type of shadow2D as sample_compare returns a scalar
+    if (is_shadow)
+    {
+        buffer.asprintf_append("float4(");
+    }
+
 	// texture name & call to sample
 	ir->sampler->accept(this);
 	if (is_shadow)
@@ -1334,6 +1340,12 @@ void ir_print_metal_visitor::visit(ir_texture *ir)
 	//@TODO: pixel offsets
 
 	buffer.asprintf_append (")");
+	
+    // Close float4 cast
+    if (is_shadow)
+    {
+        buffer.asprintf_append(")");
+    }
 }
 
 


### PR DESCRIPTION
The ES/Metal/MesaGL ecosystem is new to me right now so please correct any errors I've made.

Texture samplers are defined by default to have low precision. In Mesa's GLSL compiler, this is specified in the class `ir_texture` which initialises its `ir_rvalue` member with `glsl_precision_low`. The type is defined in `ir.h`. This decision is also reinforced in `apply_precision_to_variable` where it says: *samplers default to low precision (outside of function arguments)*.

For comparison, in glslang texture samplers are similarly set to `EpqLow` but only if the ES profile is active. Otherwise they're set to `EpqHigh`. This can be found in `TParseContext::setPrecisionDefaults` in `ParseHelper.cpp`.

So it appears that an ES-only requirement is that texture samplers default to low-precision, which is typically enough to sample 8-bit textures. For cases where higher precision is required, samplers can be annotated to provide `mediump` or `highp` precision on ES. Implied in the behaviour specified above, Mesa's GLSL compiler only cares about ES.

For what it's worth, I've checked the OpenGL Core and ES specifications and can't find mention of this behaviour anywhere so a pointer to some legalese would be great.

For Metal this can break down when required to sample high-precision textures as precision qualifiers are not a valid part of the language. All you get are low-precision values from high-precision textures that can propagate up through assignment and destroy the precision of your calculations.

This fix follows a different path for texture precision management when the Metal profile is active.