### PR TITLE
Fix memory leaks in glslopt_shader

### DIFF
--- a/src/glsl/glsl_optimizer.cpp
+++ b/src/glsl/glsl_optimizer.cpp
@@ -170,6 +170,10 @@ struct glslopt_shader
 	{
 		for (unsigned i = 0; i < MESA_SHADER_STAGES; i++)
 			ralloc_free(whole_program->_LinkedShaders[i]);
+		for(GLuint i =0;i< whole_program->NumShaders;i++)
+			ralloc_free(whole_program->Shaders[i]);
+		ralloc_free(whole_program->Shaders);
+		ralloc_free(whole_program->InfoLog);
 		ralloc_free(whole_program);
 		ralloc_free(rawOutput);
 		ralloc_free(optimizedOutput);


### PR DESCRIPTION
A few allocations made in the constructor were not being freed.